### PR TITLE
Update numpy, kick GitHub Actions cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -55,7 +56,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov wheel
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then pip install --prefer-binary -r requirements.txt; fi
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.4.3
+matplotlib>=3.4.3,==3.*
 networkx==2.6.3
 numpy>=1.20.3,==1.*
 ortools==9.2.9972

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib==3.4.3
 networkx==2.6.3
-numpy==1.20.3
+numpy==1.22.4
 ortools==9.2.9972

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib==3.4.3
 networkx==2.6.3
-numpy==1.22.4
+numpy>=1.20.3,==1.*
 ortools==9.2.9972


### PR DESCRIPTION
Another attempt at #34.

GitHub Actions is trying to re-build numpy wheels and failing. Since `requirements.txt` is our cache key, updating it might invalidate the cache. It might be a good idea to use a newer numpy anyway.