### PR TITLE
Try codecov.io for code coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-cov wheel coveralls
+          pip install flake8 pytest pytest-cov wheel
           if [ -f requirements.txt ]; then pip install --prefer-binary -r requirements.txt; fi
 
       - name: Lint with flake8
@@ -61,11 +61,5 @@ jobs:
           # Run tests and collect coverage data.
           python -m pytest
 
-      - name: Send coverage data to coveralls.io
-        run: |
-          python -m coveralls --service=github.com
-        env:
-          # COVERALLS_REPO_TOKEN helps coveralls identify our project.
-          # On GitHub, the variable is set at
-          # https://github.com/atlanticwave-sdx/pce/settings/secrets/actions
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Upload coverage to Codecov.io
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Another attempt at #76: what if we use codecov.io as an alternative to coveralls.io?