### PR TITLE
Use pygraphviz optionally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,9 +46,11 @@ jobs:
           pip install flake8 pep8-naming pytest pytest-cov wheel coveralls
           if [ -f requirements.txt ]; then pip install --prefer-binary -r requirements.txt; fi
 
-      - name: Install graphviz dependency
+      # See https://docs.github.com/en/enterprise-cloud@latest/actions/using-github-hosted-runners/customizing-github-hosted-runners
+      - name: Install libgraphviz-dev
         run: |
-          sudo apt -y install libgraphviz-dev
+          sudo apt-get update
+          sudo apt-get -y install libgraphviz-dev
 
       - name: Run some basic checks with flake8
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
           pip install flake8 pep8-naming pytest pytest-cov wheel coveralls
           if [ -f requirements.txt ]; then pip install --prefer-binary -r requirements.txt; fi
 
+      - name: Install graphviz dependency
+        run: |
+          sudo apt -y install libgraphviz-dev
+
       - name: Run some basic checks with flake8
         run: |
           # Stop the build if there are Python syntax errors or undefined names.
@@ -68,7 +72,7 @@ jobs:
           # Install package so that tests can be run.  Note that
           # editable mode install is important here -- it helps
           # coveralls.io to match coverage and sources correctly.
-          pip install --editable .[test]
+          pip install --editable .[test,pygraphviz]
           # Run tests and collect coverage data.
           python -m pytest
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Or you can use Python's unittest module:
 $ python -m unittest -v tests.LoadBalancing.test_te_solver
 ```
 
+One of the tests attempt to read a Graphviz dot file.  For this test
+to work, you will need pygraphviz, which can be installed as an
+optional dependency:
+
+```
+$ pip install --editable .[test,pygraphviz]
+```
+
 Test data is stored in `test/data` as JSON files.  You might want to
 be in the top-level directory when running tests.
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Or you can use Python's unittest module:
 
 ```console
 $ python -m unittest -v tests.LoadBalancing.test_te_solver
-$ python -m unittest -v tests.LoadBalancing.test_LB_Solver
-$ python -m unittest -v tests.LoadBalancing.test_MC_Solver
 ```
 
 Test data is stored in `test/data` as JSON files.  You might want to

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,3 @@ test =
 
 pygraphviz =
     pygraphviz
-
-pydot =
-    pydot

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,11 @@ exclude =
 
 [options.extras_require]
 test =
-    pydot
     pytest
     pytest-cov
+
+pygraphviz =
+    pygraphviz
+
+pydot =
+    pydot

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -36,31 +36,18 @@ def can_read_dot_file():
         return True
     except ImportError as e:
         print(f"pygraphviz doesn't seem to be available: {e}")
-        try:
-            # try to use pydot
-            print("Trying to use pydot")
-            nx.nx_pydot.read_dot(None)
-            return True
-        except ImportError:
-            print(f"Neither pygraphviz nor pydot seem to be available")
-            return False
+        return False
 
 
 def read_dot_file(topology_file):
     """
     Read a Graphviz dot file and return a graph.
     """
-    try:
-        # try to read dot file using pygraphviz
-        graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
-    except ImportError as e:
-        print(f"pygraphviz doesn't seem to be available: {e}")
-        try:
-            # try to use pydot
-            print("Trying to use pydot")
-            graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
-        except ImportError as e:
-            raise ImportError(f"Neither pygraphviz nor pydot seem to be available")
+    # try to read dot file using pygraphviz
+    graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
+
+    # If we must use pydot, use the line below:
+    # graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
 
     num_nodes = graph.number_of_nodes()
     mapping = dict(zip(graph, range(num_nodes)))

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -26,6 +26,25 @@ from networkx.algorithms import approximation as approx
 from sdx.pce.utils.constants import Constants
 
 
+def can_read_dot_file():
+    """
+    See if we have pygraphviz or pydot installed.
+    """
+    try:
+        # try to read dot file using pygraphviz
+        nx.nx_agraph.read_dot(None)
+        return True
+    except ImportError as e:
+        print(f"pygraphviz doesn't seem to be available: {e}")
+        try:
+            # try to use pydot
+            print("Trying to use pydot")
+            nx.nx_pydot.read_dot(None)
+            return True
+        except ImportError:
+            print(f"Neither pygraphviz nor pydot seem to be available")
+            return False
+
 def read_dot_file(topology_file):
     """
     Read a Graphviz dot file and return a graph.

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -35,7 +35,7 @@ def dot_file(topology_file, te_file=None):
             w[Constants.LATENCY] = latency
 
     connectivity = approx.node_connectivity(graph)
-    print("Connectivity:" + str(connectivity))
+    print(f"Connectivity: {connectivity}")
 
     with open(te_file) as f:
         tm = json.load(f)

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -45,6 +45,7 @@ def can_read_dot_file():
             print(f"Neither pygraphviz nor pydot seem to be available")
             return False
 
+
 def read_dot_file(topology_file):
     """
     Read a Graphviz dot file and return a graph.
@@ -60,7 +61,7 @@ def read_dot_file(topology_file):
             graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
         except ImportError as e:
             raise ImportError(f"Neither pygraphviz nor pydot seem to be available")
-        
+
     num_nodes = graph.number_of_nodes()
     mapping = dict(zip(graph, range(num_nodes)))
     graph = nx.relabel_nodes(graph, mapping)

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -1,3 +1,22 @@
+"""
+Handlers for topology description in Graphviz dot format.
+
+Topology description in dot format used to be popular.  There exist
+dot files for several well-known networks like Geant, and they were
+used for the algorithm performance study, and of course it extended
+SDX to support one more topology description format potentially from
+OXPs.
+
+This is optional since this needs's networkx's support for dot file
+format is changing -- networkx's dot file support used pydot, but
+pydot is being deprecated in favor of pygraphviz:
+
+https://github.com/networkx/networkx/issues/5723
+
+Pydot is "pure" Python, and pygraphviz is implemented as bindings to
+graphviz C library, so installing the latter is a little more work.
+"""
+
 import re
 import json
 

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -1,0 +1,47 @@
+import re
+import json
+
+import networkx as nx
+from networkx.algorithms import approximation as approx
+
+from sdx.pce.utils.constants import Constants
+
+
+def dot_file(topology_file, te_file=None):
+    graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
+    # graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
+    num_nodes = graph.number_of_nodes()
+    mapping = dict(zip(graph, range(num_nodes)))
+    graph = nx.relabel_nodes(graph, mapping)
+
+    for (u, v, w) in graph.edges(data=True):
+        if "capacity" not in w.keys():
+            bandwidth = 1000.0
+        else:
+            capacity = w["capacity"].strip('"')
+            bw = re.split(r"(\D+)", capacity)
+            bandwidth = bw[0]
+            if bw[1].startswith("G"):
+                bandwidth = float(bw[0]) * 1000
+
+        w[Constants.ORIGINAL_BANDWIDTH] = float(bandwidth)
+        w[Constants.BANDWIDTH] = float(bandwidth)
+        w[Constants.WEIGHT] = float(w["cost"])
+        if "latency" not in w.keys():
+            latency = 10
+            w[Constants.LATENCY] = latency
+
+    connectivity = approx.node_connectivity(graph)
+    print("Connectivity:" + str(connectivity))
+
+    with open(te_file) as f:
+        tm = json.load(f)
+    o_tm = []
+    for t in tm:
+        tr = tuple(t)
+        o_tm.append(tr)
+
+    return graph, o_tm
+    # connection = GetConnection('../test/data/test_connection.json')
+    # g = GetNetworkToplogy(25,0.4)
+    # print(lbnxgraphgenerator(25, 0.4,connection,g))

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -17,8 +17,8 @@ Pydot is "pure" Python, and pygraphviz is implemented as bindings to
 graphviz C library, so installing the latter is a little more work.
 """
 
-import re
 import json
+import re
 
 import networkx as nx
 from networkx.algorithms import approximation as approx

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -7,7 +7,7 @@ from networkx.algorithms import approximation as approx
 from sdx.pce.utils.constants import Constants
 
 
-def dot_file(topology_file, te_file=None):
+def read_dot_file(topology_file, te_file=None):
     """
     Read a Graphviz dot file and return a graph.
     """
@@ -45,6 +45,3 @@ def dot_file(topology_file, te_file=None):
         o_tm.append(tr)
 
     return graph, o_tm
-    # connection = GetConnection('../test/data/test_connection.json')
-    # g = GetNetworkToplogy(25,0.4)
-    # print(lbnxgraphgenerator(25, 0.4,connection,g))

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -7,7 +7,7 @@ from networkx.algorithms import approximation as approx
 from sdx.pce.utils.constants import Constants
 
 
-def read_dot_file(topology_file, te_file=None):
+def read_dot_file(topology_file):
     """
     Read a Graphviz dot file and return a graph.
     """
@@ -37,6 +37,13 @@ def read_dot_file(topology_file, te_file=None):
     connectivity = approx.node_connectivity(graph)
     print(f"Connectivity: {connectivity}")
 
+    return graph
+
+
+def read_topology_json_file(te_file):
+    """
+    Read topology described in a JSON file.
+    """
     with open(te_file) as f:
         tm = json.load(f)
     o_tm = []
@@ -44,4 +51,4 @@ def read_dot_file(topology_file, te_file=None):
         tr = tuple(t)
         o_tm.append(tr)
 
-    return graph, o_tm
+    return o_tm

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -30,8 +30,18 @@ def read_dot_file(topology_file):
     """
     Read a Graphviz dot file and return a graph.
     """
-    graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
-    # graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
+    try:
+        # try to read dot file using pygraphviz
+        graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
+    except ImportError as e:
+        print(f"pygraphviz doesn't seem to be available: {e}")
+        try:
+            # try to use pydot
+            print("Trying to use pydot")
+            graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
+        except ImportError as e:
+            raise ImportError(f"Neither pygraphviz nor pydot seem to be available")
+        
     num_nodes = graph.number_of_nodes()
     mapping = dict(zip(graph, range(num_nodes)))
     graph = nx.relabel_nodes(graph, mapping)

--- a/src/sdx/pce/utils/graphviz.py
+++ b/src/sdx/pce/utils/graphviz.py
@@ -8,6 +8,9 @@ from sdx.pce.utils.constants import Constants
 
 
 def dot_file(topology_file, te_file=None):
+    """
+    Read a Graphviz dot file and return a graph.
+    """
     graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
     # graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
     num_nodes = graph.number_of_nodes()

--- a/src/sdx/pce/utils/random_topology_generator.py
+++ b/src/sdx/pce/utils/random_topology_generator.py
@@ -5,9 +5,7 @@ Created on Tue Mar  8 13:34:06 2022
 
 @author: Yufeng Xin (yxin@renci.org)
 """
-import json
 import random
-import re
 
 import networkx as nx
 import pylab as plt
@@ -113,43 +111,3 @@ class RandomTopologyGenerator:
     def get_connectivity(self):
         con = approx.node_connectivity(self.graph)
         return con
-
-
-def dot_file(topology_file, te_file=None):
-    graph = nx.Graph(nx.nx_pydot.read_dot(topology_file))
-    # graph = nx.Graph(nx.nx_agraph.read_dot(topology_file))
-    num_nodes = graph.number_of_nodes()
-    mapping = dict(zip(graph, range(num_nodes)))
-    graph = nx.relabel_nodes(graph, mapping)
-
-    for (u, v, w) in graph.edges(data=True):
-        if "capacity" not in w.keys():
-            bandwidth = 1000.0
-        else:
-            capacity = w["capacity"].strip('"')
-            bw = re.split(r"(\D+)", capacity)
-            bandwidth = bw[0]
-            if bw[1].startswith("G"):
-                bandwidth = float(bw[0]) * 1000
-
-        w[Constants.ORIGINAL_BANDWIDTH] = float(bandwidth)
-        w[Constants.BANDWIDTH] = float(bandwidth)
-        w[Constants.WEIGHT] = float(w["cost"])
-        if "latency" not in w.keys():
-            latency = 10
-            w[Constants.LATENCY] = latency
-
-    connectivity = approx.node_connectivity(graph)
-    print("Connectivity:" + str(connectivity))
-
-    with open(te_file) as f:
-        tm = json.load(f)
-    o_tm = []
-    for t in tm:
-        tr = tuple(t)
-        o_tm.append(tr)
-
-    return graph, o_tm
-    # connection = GetConnection('../test/data/test_connection.json')
-    # g = GetNetworkToplogy(25,0.4)
-    # print(lbnxgraphgenerator(25, 0.4,connection,g))

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -117,8 +117,12 @@ class TESolverTests(unittest.TestCase):
         topology_file = os.path.join(TEST_DATA_DIR, "Geant2012.dot")
         graph = read_dot_file(topology_file)
 
+        self.assertNotEqual(graph, None, "Could not read dot file")
+
         connection_file = os.path.join(TEST_DATA_DIR, "test_connection.json")
         tm = read_topology_json_file(connection_file)
+
+        self.assertNotEqual(tm, None, "Could not read connection file")
 
         solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
         path, result = solver.solve()

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -8,7 +8,7 @@ from sdx.pce.load_balancing.te_solver import TESolver
 from sdx.pce.utils.constants import Constants
 from sdx.pce.utils.random_connection_generator import RandomConnectionGenerator
 from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator
-from sdx.pce.utils.graphviz import dot_file
+from sdx.pce.utils.graphviz import read_dot_file, read_topology_json_file
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -114,10 +114,11 @@ class TESolverTests(unittest.TestCase):
         self.assertEqual(7.0, result)
 
     def test_mc_solve_geant2012(self):
-        connection_file = os.path.join(TEST_DATA_DIR, "test_connection.json")
         topology_file = os.path.join(TEST_DATA_DIR, "Geant2012.dot")
+        graph = read_dot_file(topology_file)
 
-        graph, tm = dot_file(topology_file, connection_file)
+        connection_file = os.path.join(TEST_DATA_DIR, "test_connection.json")
+        tm = read_topology_json_file(connection_file)
 
         solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
         path, result = solver.solve()

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -8,7 +8,11 @@ from sdx.pce.load_balancing.te_solver import TESolver
 from sdx.pce.utils.constants import Constants
 from sdx.pce.utils.random_connection_generator import RandomConnectionGenerator
 from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator
-from sdx.pce.utils.graphviz import read_dot_file, read_topology_json_file
+from sdx.pce.utils.graphviz import (
+    can_read_dot_file,
+    read_dot_file,
+    read_topology_json_file,
+)
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -113,6 +117,7 @@ class TESolverTests(unittest.TestCase):
 
         self.assertEqual(7.0, result)
 
+    @unittest.skipIf(not can_read_dot_file(), reason="Can't read dot file")
     def test_mc_solve_geant2012(self):
         topology_file = os.path.join(TEST_DATA_DIR, "Geant2012.dot")
         graph = read_dot_file(topology_file)

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -7,7 +7,8 @@ import networkx as nx
 from sdx.pce.load_balancing.te_solver import TESolver
 from sdx.pce.utils.constants import Constants
 from sdx.pce.utils.random_connection_generator import RandomConnectionGenerator
-from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator, dot_file
+from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator
+from sdx.pce.utils.graphviz import dot_file
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -6,13 +6,13 @@ import networkx as nx
 
 from sdx.pce.load_balancing.te_solver import TESolver
 from sdx.pce.utils.constants import Constants
-from sdx.pce.utils.random_connection_generator import RandomConnectionGenerator
-from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator
 from sdx.pce.utils.graphviz import (
     can_read_dot_file,
     read_dot_file,
     read_topology_json_file,
 )
+from sdx.pce.utils.random_connection_generator import RandomConnectionGenerator
+from sdx.pce.utils.random_topology_generator import RandomTopologyGenerator
 
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 


### PR DESCRIPTION
Issue is #72. 

The function formerly known as `dot_file()` function has been moved to its own module, and renamed (to `read_dot_file()`), and refactored. Pygraphviz can be installed as an optional dependency, and pydot dependency has been removed.

The test that attempts to use the dot file will run only if either pygraphviz is installed. For testing with the optional dependency, run:

```
$ pip install .[test,pygraphviz]
$ pytest
```