### PR TITLE
Refactor connection breakdown logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ dmypy.json
 /tests/data/connection.json
 /tests/data/sdx-out.json
 /tests/data/sdx.png
+/tests/data/amlight.png
 
 /.coverage
 /coverage.lcov

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -407,7 +407,6 @@ class TESolver:
         print(f"out: {out.shape}")
         return out
 
-    #
     def _lhsbw(self, request_list, inputmatrix):
         """
         Form bandwidth constraints.
@@ -419,9 +418,6 @@ class TESolver:
         to this function.  The return value should represent the green
         portion, which is the bandwidth constraints computed here.
         """
-        print(f"request_list: {request_list}, inputmatrix:")
-        import pprint
-        pprint.pp(inputmatrix)
         bwconstraints = []
         # zeros = self.zerolistmaker(len(inputmatrix[0])*len(request_list))
         zeros = np.zeros(len(inputmatrix[0]) * len(request_list), dtype=int)
@@ -430,18 +426,7 @@ class TESolver:
             bwconstraints.append(addzeros)
             count = 0
 
-            print(f"bwconstraints: {bwconstraints}, i: {i}, inputmatrix: {inputmatrix}")
-            print(f"bwconstraints[i]: {bwconstraints[i]}")
-            print(f"bwconstraints[i][i + count * len(inputmatrix[0])] = {bwconstraints[i][i + count * len(inputmatrix[0])]}")
-
-            print(f"len inputmatrix[0] = {len(inputmatrix[0])}")
-
             for request in request_list:
-                print(f"i: {i}")
-                print(f"inputmatrix[0]: {inputmatrix[0]}")
-                print(f"i + count * len(inputmatrix[0]) = {i + count * len(inputmatrix[0])}")
-                print(f"bwconstraints[i][i + count * len(inputmatrix[0])] = {bwconstraints[i][i + count * len(inputmatrix[0])]}")
-                print(f"bwconstraints[i]: {bwconstraints[i]}")
                 bwconstraints[i][
                     i + count * len(inputmatrix[0])
                 ] = request.required_bandwidth

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -135,7 +135,9 @@ class TESolver:
         # returns: dict(conn request, [path]), cost
         return self._solution_translator(paths, solver.Objective().Value())
 
-    def _solution_translator(self, paths: list, cost: float) -> Union[ConnectionSolution, None]:
+    def _solution_translator(
+        self, paths: list, cost: float
+    ) -> Union[ConnectionSolution, None]:
         # extract the edge/path
         real_paths = []
         if paths is None:

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -396,6 +396,16 @@ class TESolver:
 
     #
     def _lhsbw(self, request_list, inputmatrix):
+        """
+        Form bandwidth constraints.
+
+        To learn what this means, see the formulation diagram at
+        https://github.com/atlanticwave-sdx/pce/tree/main/Documentation.
+
+        The yellow portion of the diagram is the "inputmatrix" input
+        to this function.  The return value should represent the green
+        portion, which is the bandwidth constraints computed here.
+        """
         print(f"request_list: {request_list}, inputmatrix:")
         import pprint
         pprint.pp(inputmatrix)

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -396,6 +396,9 @@ class TESolver:
 
     #
     def _lhsbw(self, request_list, inputmatrix):
+        print(f"request_list: {request_list}, inputmatrix:")
+        import pprint
+        pprint.pp(inputmatrix)
         bwconstraints = []
         # zeros = self.zerolistmaker(len(inputmatrix[0])*len(request_list))
         zeros = np.zeros(len(inputmatrix[0]) * len(request_list), dtype=int)
@@ -403,7 +406,19 @@ class TESolver:
             addzeros = copy.deepcopy(zeros)
             bwconstraints.append(addzeros)
             count = 0
+
+            print(f"bwconstraints: {bwconstraints}, i: {i}, inputmatrix: {inputmatrix}")
+            print(f"bwconstraints[i]: {bwconstraints[i]}")
+            print(f"bwconstraints[i][i + count * len(inputmatrix[0])] = {bwconstraints[i][i + count * len(inputmatrix[0])]}")
+
+            print(f"len inputmatrix[0] = {len(inputmatrix[0])}")
+
             for request in request_list:
+                print(f"i: {i}")
+                print(f"inputmatrix[0]: {inputmatrix[0]}")
+                print(f"i + count * len(inputmatrix[0]) = {i + count * len(inputmatrix[0])}")
+                print(f"bwconstraints[i][i + count * len(inputmatrix[0])] = {bwconstraints[i][i + count * len(inputmatrix[0])]}")
+                print(f"bwconstraints[i]: {bwconstraints[i]}")
                 bwconstraints[i][
                     i + count * len(inputmatrix[0])
                 ] = request.required_bandwidth

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -249,8 +249,7 @@ class TESolver:
         nodenum = self.graph.number_of_nodes()
         linknum = self.graph.number_of_edges()
 
-        print(f"\n #Nodes: {nodenum}")
-        print(f"\n #Links: {linknum}")
+        print(f"Creating data model: #nodes: {nodenum}, #links: {linknum}")
 
         # graph flow matrix
         inputmatrix, links = self._flow_matrix(self.graph)

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -264,7 +264,7 @@ class TESolver:
         # print("distance_list:"+str(np.shape(distance_list)))
         # print("latency_list:"+str(np.shape(latency_list)))
 
-        latconstraint = self._latconstraintmaker(links)
+        latconstraint = self._make_latency_constaints(links)
 
         # form the bound: rhs
         # flows: numnode*len(request)
@@ -434,7 +434,7 @@ class TESolver:
 
         return bwconstraints
 
-    def _latconstraintmaker(self, links):
+    def _make_latency_constaints(self, links):
         lhs = []
         rhs = []
 

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -480,10 +480,6 @@ class TESolver:
         latdata["lhs"] = lhs
         latdata["rhs"] = rhs
 
-        # with open('./tests/data/latconstraint.json', 'w') as json_file:
-        #    data = latdata
-        #    json.dump(data, json_file, indent=4)
-
         return latdata
 
     def is_connected(self):

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -74,6 +74,9 @@ class TESolver:
         Return the computed path and associated cost.
         """
         data = self._create_data_model()
+        if data is None:
+            print(f"Could not create a data model")
+            return ConnectionSolution(connection_map=None, cost=0)
 
         # Create the mip solver with the SCIP backend.
         solver = pywraplp.Solver.CreateSolver("SCIP")
@@ -268,6 +271,17 @@ class TESolver:
         bounds = []
         for request in self.tm.connection_requests:
             rhs = np.zeros(nodenum, dtype=int)
+
+            # Avoid going past array bounds.
+            if request.source > nodenum or request.destination > nodenum:
+                print(
+                    f"Cannot create data model: "
+                    f"request.source ({request.source}) or "
+                    f"request.destination ({request.destination}) "
+                    f" > num nodes ({nodenum})"
+                )
+                return None
+
             rhs[request.source] = -1
             rhs[request.destination] = 1
             bounds += list(rhs)

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -55,8 +55,8 @@ class TESolver:
         :param cost_flag: Cost (weight) to assign per link.
         :param objective: What to solve for: cost or load balancing.
         """
-        assert graph is not None
-        assert tm is not None
+        assert isinstance(graph, nx.Graph)
+        assert isinstance(tm, TrafficMatrix)
 
         self.graph = graph
         self.tm = tm

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -133,14 +133,14 @@ class TESolver:
             print("The problem does not have an optimal solution.")
 
         # returns: dict(conn request, [path]), cost
-        return self._solution_translator(paths), solver.Objective().Value()
+        return self._solution_translator(paths, solver.Objective().Value())
 
-    def _solution_translator(self, paths) -> Union[ConnectionSolution, None]:
+    def _solution_translator(self, paths: list, cost: float) -> Union[ConnectionSolution, None]:
         # extract the edge/path
         real_paths = []
         if paths is None:
             print("No solution: empty input")
-            return None
+            return ConnectionSolution(connection_map=None, cost=cost)
         for path in paths:
             real_path = []
             i = 0
@@ -154,7 +154,7 @@ class TESolver:
         id_connection = 0
         ordered_paths = {}
 
-        result = ConnectionSolution(connection_map={})
+        result = ConnectionSolution(connection_map={}, cost=cost)
 
         for request in self.tm.connection_requests:
             src = request.source

--- a/src/sdx/pce/models.py
+++ b/src/sdx/pce/models.py
@@ -16,7 +16,7 @@ class ConnectionRequest:
 
     source: int
     destination: int
-    required_bandwidth: Union[float, None] = None
+    required_bandwidth: float
     required_latency: Union[float, None] = None
 
     # Make ConnectionRequest hashable since it is used as key in

--- a/src/sdx/pce/models.py
+++ b/src/sdx/pce/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Mapping
+from typing import List, Mapping, Union
 
 from dataclasses_json import dataclass_json
 
@@ -16,8 +16,8 @@ class ConnectionRequest:
 
     source: int
     destination: int
-    required_bandwidth: float
-    required_latency: float
+    required_bandwidth: Union[float, None] = None
+    required_latency: Union[float, None] = None
 
     # Make ConnectionRequest hashable since it is used as key in
     # ConnectionSolution

--- a/src/sdx/pce/models.py
+++ b/src/sdx/pce/models.py
@@ -17,7 +17,7 @@ class ConnectionRequest:
     source: int
     destination: int
     required_bandwidth: float
-    required_latency: Union[float, None] = None
+    required_latency: float
 
     # Make ConnectionRequest hashable since it is used as key in
     # ConnectionSolution

--- a/src/sdx/pce/models.py
+++ b/src/sdx/pce/models.py
@@ -58,3 +58,4 @@ class ConnectionSolution:
     """
 
     connection_map: Mapping[ConnectionRequest, List[ConnectionPath]]
+    cost: float

--- a/src/sdx/pce/models.py
+++ b/src/sdx/pce/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Mapping, Union
+from typing import List, Mapping
 
 from dataclasses_json import dataclass_json
 

--- a/src/sdx/pce/topology/grenmlconverter.py
+++ b/src/sdx/pce/topology/grenmlconverter.py
@@ -30,7 +30,7 @@ class GrenmlConverter(object):
     def add_nodes(self, nodes):
         for node in nodes:
             location = node.get_location()
-            print("adding node:" + node.id)
+            print(f"adding node: {node.id}")
             self.grenml_manager.add_node(
                 node.id,
                 node.name,
@@ -60,8 +60,8 @@ class GrenmlConverter(object):
                     end_nodes.append(grenml_node)
                 else:
                     print(
-                        "This port doesn't belong to any node in the topology, likely an Interdomain port!"
-                        + port["id"]
+                        f"This port ({port['id']}) doesn't belong to any "
+                        f"node in the topology, likely an Interdomain port?"
                     )
                     inter_domain_link = True
             if not inter_domain_link:

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -71,7 +71,7 @@ class TopologyManager:
             # check the inter-domain links first.
             self.num_interdomain_link += self.inter_domain_check(topology)
             if self.num_interdomain_link == 0:
-                print("Warning: no interdomain links detected!")
+                print(f"Warning: no interdomain links detected in {topology.id}!")
 
             # Nodes
             nodes = topology.get_nodes()

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -175,7 +175,9 @@ class TopologyManager:
         for link in links:
             link_dict[link.id] = link
             for port in link.ports:
+                print(f"inter_domain_check: port: {port}")
                 interdomain_port_dict[port["id"]] = link
+                print(f"interdomain_port_dict: {len(interdomain_port_dict)}")
 
         # ToDo: raise an warning or exception
         if len(interdomain_port_dict) == 0:
@@ -186,15 +188,19 @@ class TopologyManager:
         for port_id in interdomain_port_dict:
             # print("interdomain_port:")
             # print(port_id)
+            print(f"inter_domain_check: port_id: {port_id}")
             for existing_port, existing_link in self.port_list.items():
                 # print(existing_port)
+                print(f"inter_domain_check: existing_port: {existing_port}")
                 if port_id == existing_port:
                     # print("Interdomain port:" + port_id)
+                    print(f"inter_domain_port: {port_id} == {existing_port}")
                     # remove redundant link between two domains
                     self.topology.remove_link(existing_link.id)
                     num_interdomain_link = +1
             self.port_list[port_id] = interdomain_port_dict[port_id]
 
+        print(f"inter_domain_check: num_interdomain_link: {num_interdomain_link}")
         return num_interdomain_link
 
     # adjacent matrix of the graph, in jason?

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -175,32 +175,25 @@ class TopologyManager:
         for link in links:
             link_dict[link.id] = link
             for port in link.ports:
-                print(f"inter_domain_check: port: {port}")
                 interdomain_port_dict[port["id"]] = link
-                print(f"interdomain_port_dict: {len(interdomain_port_dict)}")
 
         # ToDo: raise an warning or exception
         if len(interdomain_port_dict) == 0:
-            print("interdomain_port_dict==0")
             return False
 
         # match any ports in the existing topology
         for port_id in interdomain_port_dict:
             # print("interdomain_port:")
             # print(port_id)
-            print(f"inter_domain_check: port_id: {port_id}")
             for existing_port, existing_link in self.port_list.items():
                 # print(existing_port)
-                print(f"inter_domain_check: existing_port: {existing_port}")
                 if port_id == existing_port:
                     # print("Interdomain port:" + port_id)
-                    print(f"inter_domain_port: {port_id} == {existing_port}")
                     # remove redundant link between two domains
                     self.topology.remove_link(existing_link.id)
                     num_interdomain_link = +1
             self.port_list[port_id] = interdomain_port_dict[port_id]
 
-        print(f"inter_domain_check: num_interdomain_link: {num_interdomain_link}")
         return num_interdomain_link
 
     # adjacent matrix of the graph, in jason?

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -179,6 +179,7 @@ class TopologyManager:
 
         # ToDo: raise an warning or exception
         if len(interdomain_port_dict) == 0:
+            print("interdomain_port_dict==0")
             return False
 
         # match any ports in the existing topology

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -27,7 +27,7 @@ class TopologyManager:
     def __init__(self):
         super().__init__()
 
-        self.handler = TopologyHandler()
+        self.topology_handler = TopologyHandler()
 
         self.topology = None
         self.topology_list = {}
@@ -36,7 +36,7 @@ class TopologyManager:
         self.num_interdomain_link = 0
 
     def get_handler(self):
-        return self.handler
+        return self.topology_handler
 
     def topology_id(self, id):
         self.topology._id(id)
@@ -53,7 +53,7 @@ class TopologyManager:
         self.port_list = {}
 
     def add_topology(self, data):
-        topology = self.handler.import_topology_data(data)
+        topology = self.topology_handler.import_topology_data(data)
         self.topology_list[topology.id] = topology
 
         if self.topology is None:

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -76,11 +76,17 @@ class TEManager:
         
         return TrafficMatrix(connection_requests=[request])
 
-    def generate_graph_te(self):
+    def generate_graph_te(self) -> nx.Graph:
+        """
+        Return the topology graph that we have.
+        """
         graph = self.topology_manager.generate_graph()
         graph = nx.convert_node_labels_to_integers(graph, label_attribute="id")
+
+        # TODO: why is this needed?
         self.graph = graph
         # print(list(graph.nodes(data=True)))
+
         return graph
 
     def graph_node_connectivity(self, source=None, dest=None):

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -2,7 +2,7 @@ import networkx as nx
 from networkx.algorithms import approximation as approx
 
 from sdx.datamodel.parsing.connectionhandler import ConnectionHandler
-from sdx.pce.models import ConnectionRequest, TrafficMatrix
+from sdx.pce.models import ConnectionRequest, ConnectionSolution, TrafficMatrix
 from sdx.pce.topology.manager import TopologyManager
 
 
@@ -112,9 +112,21 @@ class TEManager:
 
         return True
 
+    def generate_connection_breakdown_tm(self, connection: ConnectionSolution):
+        assert connection is not None
+
+        breakdown = {}
+        paths = connection.connection_map  # p2p for now
+
+        # i_port = None
+        # e_port = None
+
+        for domain, links in paths.items():
+            print(f"domain: {domain}, links: {links}")
+
     def generate_connection_breakdown(self, connection):
         """
-        Take a connection
+        Take a connection and generate a breakdown.
         """
         assert connection is not None
 

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -152,6 +152,19 @@ class TEManager:
                 # determined? Can a domain be `None`?
                 print(f"source domain: {src_domain}, destination domain: {dst_domain}")
                 
+                current_link_set.append(link)
+                current_domain = src_domain
+                if src_domain == dst_domain:
+                    # current_domain = domain_1
+                    if count == len(links) - 1:
+                        breakdown[current_domain] = current_link_set.copy()
+                else:
+                    breakdown[current_domain] = current_link_set.copy()
+                    current_domain = None
+                    current_link_set = []
+
+        print(f"[intermediate] breakdown: {breakdown}")
+
 
     def generate_connection_breakdown(self, connection):
         """

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -111,6 +111,9 @@ class TEManager:
         return True
 
     def generate_connection_breakdown(self, connection):
+        """
+        Take a connection
+        """
         assert connection is not None
 
         breakdown = {}

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -2,7 +2,12 @@ import networkx as nx
 from networkx.algorithms import approximation as approx
 
 from sdx.datamodel.parsing.connectionhandler import ConnectionHandler
-from sdx.pce.models import ConnectionPath, ConnectionRequest, ConnectionSolution, TrafficMatrix
+from sdx.pce.models import (
+    ConnectionPath,
+    ConnectionRequest,
+    ConnectionSolution,
+    TrafficMatrix,
+)
 from sdx.pce.topology.manager import TopologyManager
 
 
@@ -146,14 +151,14 @@ class TEManager:
                 assert dst_node is not None
 
                 print(f"source node: {src_node}, destination node: {dst_node}")
-                
+
                 src_domain = self.topology_manager.get_domain_name(src_node.get("id"))
                 dst_domain = self.topology_manager.get_domain_name(dst_node.get("id"))
 
                 # TODO: what do we do when a domain can't be
                 # determined? Can a domain be `None`?
                 print(f"source domain: {src_domain}, destination domain: {dst_domain}")
-                
+
                 current_link_set.append(link)
                 current_domain = src_domain
                 if src_domain == dst_domain:
@@ -171,7 +176,7 @@ class TEManager:
         first = True
         i = 0
         domain_breakdown = {}
-       
+
         for domain, links in breakdown.items():
             print(f"Creating domain_breakdown: domain: {domain}, links: {links}")
             segment = {}
@@ -202,7 +207,6 @@ class TEManager:
 
         print(f"generate_connection_breakdown(): domain_breakdown: {domain_breakdown}")
         return domain_breakdown
-
 
     def generate_connection_breakdown(self, connection):
         """

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -117,12 +117,12 @@ class TEManager:
 
         return True
 
-    def generate_connection_breakdown_tm(self, connection: ConnectionSolution):
+    def generate_connection_breakdown_tm(self, connection: ConnectionSolution) -> dict:
         """
         Take a connection and generate a breakdown.
 
-        TODO: This is work in progress, and this is an alternative to
-        generate_connection_breakdown() below.
+        This is an alternative to generate_connection_breakdown()
+        below which uses the newly defined types from sdx.pce.models.
         """
         if connection is None or connection.connection_map is None:
             print(f"Can't find a breakdown for {connection}")

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -165,6 +165,42 @@ class TEManager:
 
         print(f"[intermediate] breakdown: {breakdown}")
 
+        # now starting with the ingress_port
+        first = True
+        i = 0
+        domain_breakdown = {}
+       
+        for domain, links in breakdown.items():
+            print(f"Creating domain_breakdown: domain: {domain}, links: {links}")
+            segment = {}
+            if first:
+                first = False
+                last_link = links[-1]
+                n1 = self.graph.nodes[last_link.source]["id"]
+                n2 = self.graph.nodes[last_link.destination]["id"]
+                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
+                i_port = self.connection.ingress_port.to_dict()
+                e_port = p1
+                next_i = p2
+            elif i == len(breakdown) - 1:
+                i_port = next_i
+                e_port = self.connection.egress_port.to_dict()
+            else:
+                last_link = links[-1]
+                n1 = self.graph.nodes[last_link.source]["id"]
+                n2 = self.graph.nodes[last_link.destination]["id"]
+                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
+                i_port = next_i
+                e_port = p1
+                next_i = p2
+            segment["ingress_port"] = i_port
+            segment["egress_port"] = e_port
+            domain_breakdown[domain] = segment.copy()
+            i = i + 1
+
+        print(f"generate_connection_breakdown(): domain_breakdown: {domain_breakdown}")
+        return domain_breakdown
+
 
     def generate_connection_breakdown(self, connection):
         """

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -2,7 +2,7 @@ import networkx as nx
 from networkx.algorithms import approximation as approx
 
 from sdx.datamodel.parsing.connectionhandler import ConnectionHandler
-from sdx.pce.models import ConnectionRequest, ConnectionSolution, TrafficMatrix
+from sdx.pce.models import ConnectionPath, ConnectionRequest, ConnectionSolution, TrafficMatrix
 from sdx.pce.topology.manager import TopologyManager
 
 
@@ -129,6 +129,29 @@ class TEManager:
 
         for domain, links in paths.items():
             print(f"domain: {domain}, links: {links}")
+
+            current_link_set = []
+
+            for count, link in enumerate(links):
+                print(f"count: {count}, link: {link}")
+
+                assert isinstance(link, ConnectionPath)
+
+                src_node = self.graph.nodes.get(link.source)
+                assert src_node is not None
+
+                dst_node = self.graph.nodes.get(link.destination)
+                assert dst_node is not None
+
+                print(f"source node: {src_node}, destination node: {dst_node}")
+                
+                src_domain = self.topology_manager.get_domain_name(src_node.get("id"))
+                dst_domain = self.topology_manager.get_domain_name(dst_node.get("id"))
+
+                # TODO: what do we do when a domain can't be
+                # determined? Can a domain be `None`?
+                print(f"source domain: {src_domain}, destination domain: {dst_domain}")
+                
 
     def generate_connection_breakdown(self, connection):
         """

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -23,14 +23,22 @@ class TEManager:
         self.topology_manager = TopologyManager()
         self.connection_handler = ConnectionHandler()
 
-        self.topology_manager.topology = self.topology_manager.get_handler().import_topology_data(
-            topology_data
+        self.topology_manager.topology = (
+            self.topology_manager.get_handler().import_topology_data(topology_data)
         )
         self.connection = self.connection_handler.import_connection_data(
             connection_data
         )
 
         self.graph = self.generate_graph_te()
+
+    def add_topology(self, topology_data: dict):
+        """
+        Add a new topology to TEManager.
+
+        :param topology_data: a dictionary that represents a topology.
+        """
+        self.topology_manager.add_topology(topology_data)
 
     def generate_connection_te(self):
         ingress_port = self.connection.ingress_port

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -113,6 +113,12 @@ class TEManager:
         return True
 
     def generate_connection_breakdown_tm(self, connection: ConnectionSolution):
+        """
+        Take a connection and generate a breakdown.
+
+        TODO: This is work in progress, and this is an alternative to
+        generate_connection_breakdown() below.
+        """
         assert connection is not None
 
         breakdown = {}

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -20,10 +20,10 @@ class TEManager:
     def __init__(self, topology_data, connection_data):
         super().__init__()
 
-        self.manager = TopologyManager()
+        self.topology_manager = TopologyManager()
         self.connection_handler = ConnectionHandler()
 
-        self.manager.topology = self.manager.get_handler().import_topology_data(
+        self.topology_manager.topology = self.topology_manager.get_handler().import_topology_data(
             topology_data
         )
         self.connection = self.connection_handler.import_connection_data(
@@ -34,9 +34,9 @@ class TEManager:
 
     def generate_connection_te(self):
         ingress_port = self.connection.ingress_port
-        ingress_node = self.manager.topology.get_node_by_port(ingress_port.id)
+        ingress_node = self.topology_manager.topology.get_node_by_port(ingress_port.id)
         egress_port = self.connection.egress_port
-        egress_node = self.manager.topology.get_node_by_port(egress_port.id)
+        egress_node = self.topology_manager.topology.get_node_by_port(egress_port.id)
 
         i_node = [
             x for x, y in self.graph.nodes(data=True) if y["id"] == ingress_node.id
@@ -55,7 +55,7 @@ class TEManager:
         return requests
 
     def generate_graph_te(self):
-        graph = self.manager.generate_graph()
+        graph = self.topology_manager.generate_graph()
         graph = nx.convert_node_labels_to_integers(graph, label_attribute="id")
         self.graph = graph
         # print(list(graph.nodes(data=True)))
@@ -107,8 +107,8 @@ class TEManager:
 
                 print(f"node_1: {node_1}, node_2: {node_2}")
 
-                domain_1 = self.manager.get_domain_name(node_1["id"])
-                domain_2 = self.manager.get_domain_name(node_2["id"])
+                domain_1 = self.topology_manager.get_domain_name(node_1["id"])
+                domain_2 = self.topology_manager.get_domain_name(node_2["id"])
 
                 # # TODO: handle the cases where a domain was not found.
                 # if domain_1 is None:
@@ -144,7 +144,7 @@ class TEManager:
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link[0]]["id"]
                 n2 = self.graph.nodes[last_link[1]]["id"]
-                n1, p1, n2, p2 = self.manager.topology.get_port_by_link(n1, n2)
+                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
                 i_port = self.connection.ingress_port.to_dict()
                 e_port = p1
                 next_i = p2
@@ -155,7 +155,7 @@ class TEManager:
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link[0]]["id"]
                 n2 = self.graph.nodes[last_link[1]]["id"]
-                n1, p1, n2, p2 = self.manager.topology.get_port_by_link(n1, n2)
+                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
                 i_port = next_i
                 e_port = p1
                 next_i = p2

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -119,7 +119,9 @@ class TEManager:
         TODO: This is work in progress, and this is an alternative to
         generate_connection_breakdown() below.
         """
-        assert connection is not None
+        if connection is None or connection.connection_map is None:
+            print(f"Can't find a breakdown for {connection}")
+            return None
 
         breakdown = {}
         paths = connection.connection_map  # p2p for now

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -90,19 +90,24 @@ class TEManager:
         return graph
 
     def graph_node_connectivity(self, source=None, dest=None):
-        conn = approx.node_connectivity(self.graph, source, dest)
-        return conn
+        """
+        Check that a source and destination node have connectivity.
+        """
+        # TODO: is this method really needed?
+        return approx.node_connectivity(self.graph, source, dest)
 
-    def requests_connectivity(self, requests):
-        for request in requests:
-            conn = self.graph_node_connectivity(request[0], request[1])
-            print(
-                "Request Connectivity: {}, {} = {}".format(
-                    request[0],
-                    request[1],
-                    conn,
-                )
-            )
+    def requests_connectivity(self, tm: TrafficMatrix) -> bool:
+        """
+        Check that connectivity is possible.
+        """
+        # TODO: consider using filter() and reduce(), maybe?
+        # TODO: write some tests for this method.
+        for request in tm.connection_requests:
+            # conn = self.graph_node_connectivity(request.source, request.destination)
+            print(f"Request connectivity: source {request.source}, destination: {request.destination} = {conn}" )
+            if conn is False:
+                return False
+
         return True
 
     def generate_connection_breakdown(self, connection):

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -103,7 +103,7 @@ class TEManager:
         # TODO: consider using filter() and reduce(), maybe?
         # TODO: write some tests for this method.
         for request in tm.connection_requests:
-            # conn = self.graph_node_connectivity(request.source, request.destination)
+            conn = self.graph_node_connectivity(request.source, request.destination)
             print(f"Request connectivity: source {request.source}, destination: {request.destination} = {conn}" )
             if conn is False:
                 return False

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -117,7 +117,15 @@ class TEManager:
 
         return True
 
-    def generate_connection_breakdown_tm(self, connection: ConnectionSolution) -> dict:
+    def generate_connection_breakdown(self, connection) -> dict:
+        """
+        A "router" method for backward compatibility.
+        """
+        if isinstance(connection, ConnectionSolution):
+            return self._generate_connection_breakdown_tm(connection)
+        return self._generate_connection_breakdown_old(connection)
+
+    def _generate_connection_breakdown_tm(self, connection: ConnectionSolution) -> dict:
         """
         Take a connection and generate a breakdown.
 
@@ -208,7 +216,7 @@ class TEManager:
         print(f"generate_connection_breakdown(): domain_breakdown: {domain_breakdown}")
         return domain_breakdown
 
-    def generate_connection_breakdown(self, connection):
+    def _generate_connection_breakdown_old(self, connection):
         """
         Take a connection and generate a breakdown.
         """

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -2,8 +2,8 @@ import networkx as nx
 from networkx.algorithms import approximation as approx
 
 from sdx.datamodel.parsing.connectionhandler import ConnectionHandler
-from sdx.pce.topology.manager import TopologyManager
 from sdx.pce.models import ConnectionRequest, TrafficMatrix
+from sdx.pce.topology.manager import TopologyManager
 
 
 class TEManager:

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -53,7 +53,7 @@ class TEManager:
         ingress_nodes = [
             x for x, y in self.graph.nodes(data=True) if y["id"] == ingress_node.id
         ]
-        
+
         egress_nodes = [
             x for x, y in self.graph.nodes(data=True) if y["id"] == egress_node.id
         ]
@@ -68,12 +68,12 @@ class TEManager:
         required_latency = self.connection.latency
 
         request = ConnectionRequest(
-            source = ingress_nodes[0],
-            destination = egress_nodes[0],
-            required_bandwidth = required_bandwidth,
-            required_latency = required_latency
+            source=ingress_nodes[0],
+            destination=egress_nodes[0],
+            required_bandwidth=required_bandwidth,
+            required_latency=required_latency,
         )
-        
+
         return TrafficMatrix(connection_requests=[request])
 
     def generate_graph_te(self) -> nx.Graph:
@@ -104,7 +104,9 @@ class TEManager:
         # TODO: write some tests for this method.
         for request in tm.connection_requests:
             conn = self.graph_node_connectivity(request.source, request.destination)
-            print(f"Request connectivity: source {request.source}, destination: {request.destination} = {conn}" )
+            print(
+                f"Request connectivity: source {request.source}, destination: {request.destination} = {conn}"
+            )
             if conn is False:
                 return False
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -162,6 +162,7 @@ class TEManagerTests(unittest.TestCase):
         self.temanager.generate_connection_breakdown_tm(solution)
 
     def test_connection_breakdown_two_similar_requests(self):
+        # Solving and breaking down two similar connection requests.
         request = [
             {
                 "1": [[1, 2], [3, 4]],
@@ -170,9 +171,27 @@ class TEManagerTests(unittest.TestCase):
             1.0,
         ]
 
-        breakdown = self.temanager.generate_connection_breakdown(request)
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Make a connection request.
+        tm = make_traffic_matrix(request)
+        print(f"tm: {tm}")
+
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Find a connection solution.
+        solver = TESolver(self.temanager.graph, tm)
+        print(f"solver: {solver}")
+
+        solution = solver.solve()
+        print(f"solution: {solution}")
+
+        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
         print(f"Breakdown: {breakdown}")
         self.assertIsNotNone(breakdown)
+        self.assertIsInstance(breakdown, dict)
         self.assertEqual(len(breakdown), 1)
 
     def test_connection_breakdown_three_domains(self):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -2,6 +2,8 @@ import json
 import pathlib
 import unittest
 
+import networkx as nx
+
 from sdx.pce.topology.temanager import TEManager
 from sdx.pce.models import TrafficMatrix
 
@@ -123,6 +125,7 @@ class TestTEManager(unittest.TestCase):
         print(f"tm: {tm}")
 
         self.assertIsNotNone(graph)
+        self.assertIsInstance(graph, nx.Graph)
 
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -108,6 +108,26 @@ class TEManagerTests(unittest.TestCase):
 
         return connection
 
+    def _make_tm_and_solve(self, request):
+        # Make a traffic matrix from plain old style requests (used in
+        # the test methods below), and solve it.
+        
+        # Make a connection request.
+        tm = make_traffic_matrix(request)
+        print(f"tm: {tm}")
+
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Find a connection solution.
+        solver = TESolver(self.temanager.graph, tm)
+        print(f"solver: {solver}")
+
+        solution = solver.solve()
+        print(f"solution: {solution}")
+
+        return solution
+
     def test_generate_solver_input(self):
         print("Test Convert Connection To Topology")
         connection = self._make_connection()
@@ -141,19 +161,7 @@ class TEManagerTests(unittest.TestCase):
             1.0,
         ]
 
-        # Make a connection request.
-        tm = make_traffic_matrix(request)
-        print(f"tm: {tm}")
-
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Find a connection solution.
-        solver = TESolver(self.temanager.graph, tm)
-        print(f"solver: {solver}")
-
-        solution = solver.solve()
-        print(f"solution: {solution}")
+        solution = self._make_tm_and_solve(request)
 
         # We must have found a solution.
         self.assertIsNotNone(solution.connection_map)
@@ -175,25 +183,13 @@ class TEManagerTests(unittest.TestCase):
             1.0,
         ]
 
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Make a connection request.
-        tm = make_traffic_matrix(request)
-        print(f"tm: {tm}")
-
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Find a connection solution.
-        solver = TESolver(self.temanager.graph, tm)
-        print(f"solver: {solver}")
-
-        solution = solver.solve()
-        print(f"solution: {solution}")
+        solution = self._make_tm_and_solve(request)
+        self.assertIsNotNone(solution.connection_map)
+        self.assertNotEqual(solution.cost, 0)
 
         breakdown = self.temanager.generate_connection_breakdown_tm(solution)
         print(f"Breakdown: {breakdown}")
+
         self.assertIsNotNone(breakdown)
         self.assertIsInstance(breakdown, dict)
         self.assertEqual(len(breakdown), 1)
@@ -218,22 +214,9 @@ class TEManagerTests(unittest.TestCase):
             1.0,
         ]
 
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Make a connection request.
-        tm = make_traffic_matrix(request)
-        print(f"tm: {tm}")
-
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Find a connection solution.
-        solver = TESolver(self.temanager.graph, tm)
-        print(f"solver: {solver}")
-
-        solution = solver.solve()
-        print(f"solution: {solution}")
+        solution = self._make_tm_and_solve(request)
+        self.assertIsNotNone(solution.connection_map)
+        self.assertNotEqual(solution.cost, 0)
 
         breakdown = self.temanager.generate_connection_breakdown_tm(solution)
         print(f"Breakdown: {breakdown}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -226,8 +226,9 @@ class TEManagerTests(unittest.TestCase):
         self.assertEqual(len(breakdown), 2)
 
     def test_connection_breakdown_some_input(self):
-        self._make_connection()
-
+        # The set of requests below should fail to find a solution,
+        # because our graph at this point do not have enough nodes as
+        # assumed by the request.
         request = [
             {
                 "1": [[1, 9], [9, 11]],
@@ -237,17 +238,15 @@ class TEManagerTests(unittest.TestCase):
             14195698.0,
         ]
 
-        make_traffic_matrix(request)
+        solution = self._make_tm_and_solve(request)
+        self.assertIsNone(solution.connection_map)
+        self.assertEqual(solution.cost, 0)
 
-        # solution = self._make_tm_and_solve(request)
-        # self.assertIsNotNone(solution.connection_map)
-        # self.assertNotEqual(solution.cost, 0)
-
-        # # TODO: use the the necessary setup so that a connection
-        # # breakdown can work correctly and without raising errors.
-        # with self.assertRaises(AssertionError):
-        #     breakdown = self.temanager.generate_connection_breakdown_tm(request)
-        #     print(f"Breakdown: {breakdown}")
+        # TODO: use the the necessary setup so that a connection
+        # breakdown can work correctly and without raising errors.
+        with self.assertRaises(AssertionError):
+            breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+            print(f"Breakdown: {breakdown}")
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -159,8 +159,11 @@ class TestTEManager(unittest.TestCase):
         solution = solver.solve()
         print(f"solution: {solution}")
 
-        if solution.connection_map is not None:
-            self.temanager.generate_connection_breakdown_tm(solution)
+        # We must have found a solution.
+        self.assertIsNotNone(solution.connection_map)
+        self.assertNotEqual(solution.cost, 0)
+
+        self.temanager.generate_connection_breakdown_tm(solution)
 
         # # Expect an error, for now.
         # with self.assertRaises(Exception):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -87,7 +87,7 @@ class TestTEManager(unittest.TestCase):
         request = [
             {
                 "1": [[1, 2], [3, 4]],
-                "2": [[1, 2], [3, 10]],
+                "2": [[1, 2], [3, 5]],
             },
             1.0,
         ]

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -3,7 +3,7 @@ import pathlib
 import unittest
 
 from sdx.pce.topology.temanager import TEManager
-
+from sdx.pce.models import TrafficMatrix
 
 class TestTEManager(unittest.TestCase):
     """
@@ -123,4 +123,6 @@ class TestTEManager(unittest.TestCase):
         print(f"tm: {tm}")
 
         self.assertIsNotNone(graph)
+
         self.assertIsNotNone(tm)
+        self.assertIsInstance(tm, TrafficMatrix)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -52,13 +52,13 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
             source = request[0]
             destination = request[1]
 
-            if len(requests) >= 3:
+            if len(request) >= 3:
                 required_bandwidth = request[2]
             else:
                 # Use a very low default bandwith value in tests.
                 required_bandwidth = 1
 
-            if len(requests) >= 4:
+            if len(request) >= 4:
                 required_latency = request[3]
             else:
                 # Use a very high latency default latency value in tests.
@@ -237,11 +237,17 @@ class TEManagerTests(unittest.TestCase):
             14195698.0,
         ]
 
-        # TODO: use the the necessary setup so that a connection
-        # breakdown can work correctly and without raising errors.
-        with self.assertRaises(AssertionError):
-            breakdown = self.temanager.generate_connection_breakdown(request)
-            print(f"Breakdown: {breakdown}")
+        make_traffic_matrix(request)
+
+        # solution = self._make_tm_and_solve(request)
+        # self.assertIsNotNone(solution.connection_map)
+        # self.assertNotEqual(solution.cost, 0)
+
+        # # TODO: use the the necessary setup so that a connection
+        # # breakdown can work correctly and without raising errors.
+        # with self.assertRaises(AssertionError):
+        #     breakdown = self.temanager.generate_connection_breakdown_tm(request)
+        #     print(f"Breakdown: {breakdown}")
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -214,10 +214,29 @@ class TEManagerTests(unittest.TestCase):
             1.0,
         ]
 
-        breakdown = self.temanager.generate_connection_breakdown(request)
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Make a connection request.
+        tm = make_traffic_matrix(request)
+        print(f"tm: {tm}")
+
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Find a connection solution.
+        solver = TESolver(self.temanager.graph, tm)
+        print(f"solver: {solver}")
+
+        solution = solver.solve()
+        print(f"solution: {solution}")
+
+        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
         print(f"Breakdown: {breakdown}")
+
         self.assertIsNotNone(breakdown)
-        self.assertEqual(len(breakdown), 1)
+        self.assertIsInstance(breakdown, dict)
+        self.assertEqual(len(breakdown), 2)
 
     def test_connection_breakdown_some_input(self):
         self._make_connection()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -159,7 +159,11 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        self.temanager.generate_connection_breakdown_tm(solution)
+        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        print(f"Breakdown: {breakdown}")
+        self.assertIsNotNone(breakdown)
+        self.assertIsInstance(breakdown, dict)
+        self.assertEqual(len(breakdown), 1)
 
     def test_connection_breakdown_two_similar_requests(self):
         # Solving and breaking down two similar connection requests.

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -53,6 +53,7 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
                 ConnectionRequest(
                     source=request[0],
                     destination=request[1],
+                    required_bandwidth=0,
                 )
             )
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -10,73 +10,6 @@ from sdx.pce.models import ConnectionPath, ConnectionRequest, TrafficMatrix
 from sdx.pce.topology.temanager import TEManager
 
 
-def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
-    """
-    Make a traffic matrix from the old-style list.
-
-    The list contains a map of requests and cost.  The map contains a
-    string key (TODO: what is this key?) and a list of lists as
-    value, like so::
-
-        [
-            {
-                "1": [[1, 2], [3, 4]],
-                "2": [[1, 2], [3, 4]],
-            },
-            1.0,
-        ]
-
-    """
-    assert isinstance(old_style_request, list)
-    assert len(old_style_request) == 2
-
-    requests_map = old_style_request[0]
-
-    # TODO: what to do with this? Is it even a cost?
-    cost = old_style_request[1]
-    print(f"cost: {cost}")
-
-    new_requests: list(ConnectionRequest) = []
-
-    print(f"type of request: {type(requests_map)}")
-    assert isinstance(requests_map, dict)
-
-    for key, requests in requests_map.items():
-        assert isinstance(key, str)
-        assert isinstance(requests, list)
-        assert len(requests) > 0
-
-        print(f"key: {key}, request: {requests}")
-
-        for request in requests:
-            source = request[0]
-            destination = request[1]
-
-            if len(request) >= 3:
-                required_bandwidth = request[2]
-            else:
-                # Use a very low default bandwith value in tests.
-                required_bandwidth = 1
-
-            if len(request) >= 4:
-                required_latency = request[3]
-            else:
-                # Use a very high latency default latency value in tests.
-                required_latency = 100
-
-            assert len(request) == 2
-            new_requests.append(
-                ConnectionRequest(
-                    source=source,
-                    destination=destination,
-                    required_bandwidth=required_bandwidth,
-                    required_latency=required_latency,
-                )
-            )
-
-    return TrafficMatrix(connection_requests=new_requests)
-
-
 class TEManagerTests(unittest.TestCase):
     """
     Tests for topology related functions.
@@ -113,7 +46,7 @@ class TEManagerTests(unittest.TestCase):
         # the test methods below), and solve it.
 
         # Make a connection request.
-        tm = make_traffic_matrix(request)
+        tm = self._make_traffic_matrix(request)
         print(f"tm: {tm}")
 
         print(f"graph: {self.temanager.graph}")
@@ -258,3 +191,69 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
+
+    def _make_traffic_matrix(self, old_style_request: list) -> TrafficMatrix:
+        """
+        Make a traffic matrix from the old-style list.
+    
+        The list contains a map of requests and cost.  The map contains a
+        string key (TODO: what is this key?) and a list of lists as
+        value, like so::
+    
+            [
+                {
+                    "1": [[1, 2], [3, 4]],
+                    "2": [[1, 2], [3, 4]],
+                },
+                1.0,
+            ]
+    
+        """
+        assert isinstance(old_style_request, list)
+        assert len(old_style_request) == 2
+    
+        requests_map = old_style_request[0]
+    
+        # TODO: what to do with this? Is it even a cost?
+        cost = old_style_request[1]
+        print(f"cost: {cost}")
+    
+        new_requests: list(ConnectionRequest) = []
+    
+        print(f"type of request: {type(requests_map)}")
+        assert isinstance(requests_map, dict)
+    
+        for key, requests in requests_map.items():
+            assert isinstance(key, str)
+            assert isinstance(requests, list)
+            assert len(requests) > 0
+    
+            print(f"key: {key}, request: {requests}")
+    
+            for request in requests:
+                source = request[0]
+                destination = request[1]
+    
+                if len(request) >= 3:
+                    required_bandwidth = request[2]
+                else:
+                    # Use a very low default bandwith value in tests.
+                    required_bandwidth = 1
+    
+                if len(request) >= 4:
+                    required_latency = request[3]
+                else:
+                    # Use a very high latency default latency value in tests.
+                    required_latency = 100
+    
+                assert len(request) == 2
+                new_requests.append(
+                    ConnectionRequest(
+                        source=source,
+                        destination=destination,
+                        required_bandwidth=required_bandwidth,
+                        required_latency=required_latency,
+                    )
+                )
+    
+        return TrafficMatrix(connection_requests=new_requests)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -111,7 +111,7 @@ class TEManagerTests(unittest.TestCase):
     def _make_tm_and_solve(self, request):
         # Make a traffic matrix from plain old style requests (used in
         # the test methods below), and solve it.
-        
+
         # Make a connection request.
         tm = make_traffic_matrix(request)
         print(f"tm: {tm}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -4,7 +4,7 @@ import unittest
 
 import networkx as nx
 
-from sdx.pce.models import ConnectionRequest, TrafficMatrix
+from sdx.pce.models import ConnectionPath, ConnectionRequest, TrafficMatrix
 from sdx.pce.topology.temanager import TEManager
 
 
@@ -121,12 +121,22 @@ class TestTEManager(unittest.TestCase):
         ]
 
         tm = make_traffic_matrix(request)
+        print(f"tm: {tm}")
 
-        # Expect an error, for now.
-        with self.assertRaises(Exception):
-            breakdown = self.temanager.generate_connection_breakdown(tm)
-            print(f"Breakdown: {breakdown}")
-            self.assertIsNotNone(breakdown)
+        for cr in tm.connection_requests:
+            print(f"cr: {cr}")
+            paths = [
+                ConnectionPath(source=1, destination=2),
+                ConnectionPath(source=3, destination=4),
+            ]
+
+        # self.temanager.generate_connection_breakdown(tm)
+
+        # # Expect an error, for now.
+        # with self.assertRaises(Exception):
+        #     breakdown = self.temanager.generate_connection_breakdown(tm)
+        #     print(f"Breakdown: {breakdown}")
+        #     self.assertIsNotNone(breakdown)
 
     def test_connection_breakdown_two_similar_requests(self):
         request = [

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -47,21 +47,22 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
 
         print(f"key: {key}, request: {requests}")
 
-        source = requests[0]
-        destination = requests[1]
-
-        if len(requests) >= 3:
-            required_bandwidth=requests[2]
-        else:
-            required_bandwidth=1
-
-        if len(requests) >= 4:
-            required_latency=requests[3]
-        else:
-            required_latency=100
-        
-
         for request in requests:
+            source = request[0]
+            destination = request[1]
+
+            if len(requests) >= 3:
+                required_bandwidth = request[2]
+            else:
+                # Use a very low default bandwith value in tests.
+                required_bandwidth = 1
+
+            if len(requests) >= 4:
+                required_latency = request[3]
+            else:
+                # Use a very high latency default latency value in tests.
+                required_latency = 100
+
             assert len(request) == 2
             new_requests.append(
                 ConnectionRequest(
@@ -150,8 +151,9 @@ class TEManagerTests(unittest.TestCase):
 
         print(f"graph: {self.temanager.graph}")
         import pprint
+
         pprint.pp(nx.to_dict_of_dicts(self.temanager.graph))
-                        
+
         # Find a connection solution.
         solver = TESolver(self.temanager.graph, tm)
         print(f"solver: {solver}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -47,14 +47,28 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
 
         print(f"key: {key}, request: {requests}")
 
+        source = requests[0]
+        destination = requests[1]
+
+        if len(requests) >= 3:
+            required_bandwidth=requests[2]
+        else:
+            required_bandwidth=1
+
+        if len(requests) >= 4:
+            required_latency=requests[3]
+        else:
+            required_latency=100
+        
+
         for request in requests:
             assert len(request) == 2
             new_requests.append(
                 ConnectionRequest(
-                    source=request[0],
-                    destination=request[1],
-                    required_bandwidth=0,
-                    required_latency=0,
+                    source=source,
+                    destination=destination,
+                    required_bandwidth=required_bandwidth,
+                    required_latency=required_latency,
                 )
             )
 
@@ -133,6 +147,10 @@ class TestTEManager(unittest.TestCase):
         #         ConnectionPath(source=1, destination=2),
         #         ConnectionPath(source=3, destination=4),
         #     ]
+
+        print(f"graph: {self.temanager.graph}")
+        import pprint
+        pprint.pp(nx.to_dict_of_dicts(self.temanager.graph))
                         
         # Find a connection solution.
         solver = TESolver(self.temanager.graph, tm)
@@ -141,7 +159,8 @@ class TestTEManager(unittest.TestCase):
         solution = solver.solve()
         print(f"solution: {solution}")
 
-        self.temanager.generate_connection_breakdown_tm(solution)
+        if solution.connection_map is not None:
+            self.temanager.generate_connection_breakdown_tm(solution)
 
         # # Expect an error, for now.
         # with self.assertRaises(Exception):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -4,8 +4,8 @@ import unittest
 
 import networkx as nx
 
-from sdx.pce.topology.temanager import TEManager
 from sdx.pce.models import ConnectionRequest, TrafficMatrix
+from sdx.pce.topology.temanager import TEManager
 
 
 def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -40,7 +40,6 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
     assert isinstance(requests_map, dict)
 
     for key, requests in requests_map.items():
-
         assert isinstance(key, str)
         assert isinstance(requests, list)
         assert len(requests) > 0

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -75,7 +75,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        breakdown = self.temanager.generate_connection_breakdown(solution)
         print(f"Breakdown: {breakdown}")
         self.assertIsNotNone(breakdown)
         self.assertIsInstance(breakdown, dict)
@@ -95,7 +95,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        breakdown = self.temanager.generate_connection_breakdown(solution)
         print(f"Breakdown: {breakdown}")
 
         self.assertIsNotNone(breakdown)
@@ -126,7 +126,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        breakdown = self.temanager.generate_connection_breakdown(solution)
         print(f"Breakdown: {breakdown}")
 
         self.assertIsNotNone(breakdown)
@@ -151,7 +151,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertEqual(solution.cost, 0)
 
         # If there's no solution, there should be no breakdown either.
-        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        breakdown = self.temanager.generate_connection_breakdown(solution)
         self.assertIsNone(breakdown)
 
     def test_generate_graph_and_connection(self):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -31,36 +31,6 @@ class TEManagerTests(unittest.TestCase):
 
         self.temanager = TEManager(topology_data, connection_data)
 
-    def _make_connection(self):
-        graph = self.temanager.graph
-        print(f"Generated networkx graph of the topology: {graph}")
-        print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")
-
-        connection = self.temanager.generate_connection_te()
-        print(f"connection: {connection}")
-
-        return connection
-
-    def _make_tm_and_solve(self, request):
-        # Make a traffic matrix from plain old style requests (used in
-        # the test methods below), and solve it.
-
-        # Make a connection request.
-        tm = self._make_traffic_matrix(request)
-        print(f"tm: {tm}")
-
-        print(f"graph: {self.temanager.graph}")
-        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
-
-        # Find a connection solution.
-        solver = TESolver(self.temanager.graph, tm)
-        print(f"solver: {solver}")
-
-        solution = solver.solve()
-        print(f"solution: {solution}")
-
-        return solution
-
     def test_generate_solver_input(self):
         print("Test Convert Connection To Topology")
         connection = self._make_connection()
@@ -192,14 +162,44 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
 
+    def _make_connection(self):
+        graph = self.temanager.graph
+        print(f"Generated networkx graph of the topology: {graph}")
+        print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")
+
+        connection = self.temanager.generate_connection_te()
+        print(f"connection: {connection}")
+
+        return connection
+
+    def _make_tm_and_solve(self, request):
+        # Make a traffic matrix from plain old style requests (used in
+        # the test methods below), and solve it.
+
+        # Make a connection request.
+        tm = self._make_traffic_matrix(request)
+        print(f"tm: {tm}")
+
+        print(f"graph: {self.temanager.graph}")
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
+
+        # Find a connection solution.
+        solver = TESolver(self.temanager.graph, tm)
+        print(f"solver: {solver}")
+
+        solution = solver.solve()
+        print(f"solution: {solution}")
+
+        return solution
+
     def _make_traffic_matrix(self, old_style_request: list) -> TrafficMatrix:
         """
         Make a traffic matrix from the old-style list.
-    
+
         The list contains a map of requests and cost.  The map contains a
         string key (TODO: what is this key?) and a list of lists as
         value, like so::
-    
+
             [
                 {
                     "1": [[1, 2], [3, 4]],
@@ -207,45 +207,45 @@ class TEManagerTests(unittest.TestCase):
                 },
                 1.0,
             ]
-    
+
         """
         assert isinstance(old_style_request, list)
         assert len(old_style_request) == 2
-    
+
         requests_map = old_style_request[0]
-    
+
         # TODO: what to do with this? Is it even a cost?
         cost = old_style_request[1]
         print(f"cost: {cost}")
-    
+
         new_requests: list(ConnectionRequest) = []
-    
+
         print(f"type of request: {type(requests_map)}")
         assert isinstance(requests_map, dict)
-    
+
         for key, requests in requests_map.items():
             assert isinstance(key, str)
             assert isinstance(requests, list)
             assert len(requests) > 0
-    
+
             print(f"key: {key}, request: {requests}")
-    
+
             for request in requests:
                 source = request[0]
                 destination = request[1]
-    
+
                 if len(request) >= 3:
                     required_bandwidth = request[2]
                 else:
                     # Use a very low default bandwith value in tests.
                     required_bandwidth = 1
-    
+
                 if len(request) >= 4:
                     required_latency = request[3]
                 else:
                     # Use a very high latency default latency value in tests.
                     required_latency = 100
-    
+
                 assert len(request) == 2
                 new_requests.append(
                     ConnectionRequest(
@@ -255,5 +255,5 @@ class TEManagerTests(unittest.TestCase):
                         required_latency=required_latency,
                     )
                 )
-    
+
         return TrafficMatrix(connection_requests=new_requests)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -143,13 +143,6 @@ class TEManagerTests(unittest.TestCase):
         tm = make_traffic_matrix(request)
         print(f"tm: {tm}")
 
-        # for cr in tm.connection_requests:
-        #     print(f"cr: {cr}")
-        #     paths = [
-        #         ConnectionPath(source=1, destination=2),
-        #         ConnectionPath(source=3, destination=4),
-        #     ]
-
         print(f"graph: {self.temanager.graph}")
         print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
 
@@ -165,12 +158,6 @@ class TEManagerTests(unittest.TestCase):
         self.assertNotEqual(solution.cost, 0)
 
         self.temanager.generate_connection_breakdown_tm(solution)
-
-        # # Expect an error, for now.
-        # with self.assertRaises(Exception):
-        #     breakdown = self.temanager.generate_connection_breakdown(tm)
-        #     print(f"Breakdown: {breakdown}")
-        #     self.assertIsNotNone(breakdown)
 
     def test_connection_breakdown_two_similar_requests(self):
         request = [

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -4,6 +4,7 @@ import unittest
 
 import networkx as nx
 
+from sdx.pce.load_balancing.te_solver import TESolver
 from sdx.pce.models import ConnectionPath, ConnectionRequest, TrafficMatrix
 from sdx.pce.topology.temanager import TEManager
 
@@ -120,17 +121,25 @@ class TestTEManager(unittest.TestCase):
             1.0,
         ]
 
+        # Make a connection request.
         tm = make_traffic_matrix(request)
         print(f"tm: {tm}")
 
-        for cr in tm.connection_requests:
-            print(f"cr: {cr}")
-            paths = [
-                ConnectionPath(source=1, destination=2),
-                ConnectionPath(source=3, destination=4),
-            ]
+        # for cr in tm.connection_requests:
+        #     print(f"cr: {cr}")
+        #     paths = [
+        #         ConnectionPath(source=1, destination=2),
+        #         ConnectionPath(source=3, destination=4),
+        #     ]
+                        
+        # Find a connection solution.
+        solver = TESolver(self.temanager.graph, tm)
+        print(f"solver: {solver}")
 
-        # self.temanager.generate_connection_breakdown(tm)
+        solution = solver.solve()
+        print(f"solution: {solution}")
+
+        self.temanager.generate_connection_breakdown_tm(solution)
 
         # # Expect an error, for now.
         # with self.assertRaises(Exception):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -54,6 +54,7 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
                     source=request[0],
                     destination=request[1],
                     required_bandwidth=0,
+                    required_latency=0,
                 )
             )
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -6,7 +6,12 @@ import unittest
 import networkx as nx
 
 from sdx.pce.load_balancing.te_solver import TESolver
-from sdx.pce.models import ConnectionPath, ConnectionRequest, TrafficMatrix
+from sdx.pce.models import (
+    ConnectionPath,
+    ConnectionRequest,
+    ConnectionSolution,
+    TrafficMatrix,
+)
 from sdx.pce.topology.temanager import TEManager
 
 
@@ -172,9 +177,11 @@ class TEManagerTests(unittest.TestCase):
 
         return connection
 
-    def _make_tm_and_solve(self, request):
-        # Make a traffic matrix from plain old style requests (used in
-        # the test methods below), and solve it.
+    def _make_tm_and_solve(self, request) -> ConnectionSolution:
+        """
+        Make a traffic matrix from plain old style requests (used in
+        the test methods below), and solve it.
+        """
 
         # Make a connection request.
         tm = self._make_traffic_matrix(request)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -77,12 +77,12 @@ class TestTEManager(unittest.TestCase):
         # step. Add SAX topology.
         with open(self.TOPOLOGY_FILE_SAX, "r", encoding="utf-8") as fp:
             topology_data = json.load(fp)
-            self.temanager.manager.add_topology(topology_data)
+            self.temanager.add_topology(topology_data)
 
         # Add ZAOXI topology as well.
         with open(self.TOPOLOGY_FILE_SAX, "r", encoding="utf-8") as fp:
             topology_data = json.load(fp)
-            self.temanager.manager.add_topology(topology_data)
+            self.temanager.add_topology(topology_data)
 
         request = [
             {

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -242,11 +242,9 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNone(solution.connection_map)
         self.assertEqual(solution.cost, 0)
 
-        # TODO: use the the necessary setup so that a connection
-        # breakdown can work correctly and without raising errors.
-        with self.assertRaises(AssertionError):
-            breakdown = self.temanager.generate_connection_breakdown_tm(solution)
-            print(f"Breakdown: {breakdown}")
+        # If there's no solution, there should be no breakdown either.
+        breakdown = self.temanager.generate_connection_breakdown_tm(solution)
+        self.assertIsNone(breakdown)
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -119,6 +119,8 @@ class TEManagerTests(unittest.TestCase):
             self.temanager.generate_connection_breakdown(None)
 
     def test_connection_breakdown_simple(self):
+        # Test that the old way, which had plain old dicts and arrays
+        # representing connection requests, still works.
         request = [
             {
                 "1": [[1, 2], [3, 4]],

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -11,11 +11,14 @@ class TestTEManager(unittest.TestCase):
     """
 
     TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath("data")
-    TOPOLOGY_FILE = TEST_DATA_DIR.joinpath("sdx.json")
+    TOPOLOGY_FILE_SDX = TEST_DATA_DIR.joinpath("sdx.json")
+    TOPOLOGY_FILE_ZAOXI = TEST_DATA_DIR.joinpath("zaoxi.json")
+    TOPOLOGY_FILE_SAX = TEST_DATA_DIR.joinpath("sax.json")
+
     CONNECTION_REQ_FILE = TEST_DATA_DIR.joinpath("test_request.json")
 
     def setUp(self):
-        with open(self.TOPOLOGY_FILE, "r", encoding="utf-8") as fp:
+        with open(self.TOPOLOGY_FILE_SDX, "r", encoding="utf-8") as fp:
             topology_data = json.load(fp)
 
         with open(self.CONNECTION_REQ_FILE, "r", encoding="utf-8") as fp:
@@ -60,6 +63,31 @@ class TestTEManager(unittest.TestCase):
             {
                 "1": [[1, 2], [3, 4]],
                 "2": [[1, 2], [3, 4]],
+            },
+            1.0,
+        ]
+
+        breakdown = self.temanager.generate_connection_breakdown(request)
+        print(f"Breakdown: {breakdown}")
+        self.assertIsNotNone(breakdown)
+        self.assertEqual(len(breakdown), 1)
+
+    def test_connection_breakdown_three_domains(self):
+        # SDX already exists in the known topology from setUp
+        # step. Add SAX topology.
+        with open(self.TOPOLOGY_FILE_SAX, "r", encoding="utf-8") as fp:
+            topology_data = json.load(fp)
+            self.temanager.manager.add_topology(topology_data)
+
+        # Add ZAOXI topology as well.
+        with open(self.TOPOLOGY_FILE_SAX, "r", encoding="utf-8") as fp:
+            topology_data = json.load(fp)
+            self.temanager.manager.add_topology(topology_data)
+
+        request = [
+            {
+                "1": [[1, 2], [3, 4]],
+                "2": [[1, 2], [3, 10]],
             },
             1.0,
         ]

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -75,7 +75,7 @@ def make_traffic_matrix(old_style_request: list) -> TrafficMatrix:
     return TrafficMatrix(connection_requests=new_requests)
 
 
-class TestTEManager(unittest.TestCase):
+class TEManagerTests(unittest.TestCase):
     """
     Tests for topology related functions.
     """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import pprint
 import unittest
 
 import networkx as nx
@@ -150,9 +151,7 @@ class TEManagerTests(unittest.TestCase):
         #     ]
 
         print(f"graph: {self.temanager.graph}")
-        import pprint
-
-        pprint.pp(nx.to_dict_of_dicts(self.temanager.graph))
+        print(f"graph: {pprint.pformat(nx.to_dict_of_dicts(self.temanager.graph))}")
 
         # Find a connection solution.
         solver = TESolver(self.temanager.graph, tm)

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -43,9 +43,8 @@ class TESolverTests(unittest.TestCase):
         tm = self.make_random_traffic_matrix()
         print(f"tm: {tm}")
 
-        solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
-        solution, value = solver.solve()
-        print(f"Paths: {solution}, optimal: {value}")
+        solution = TESolver(graph, tm, Constants.COST_FLAG_HOP).solve()
+        print(f"Solution: {solution}")
 
         # Check that there's a solution for each request.
         self.assertEqual(len(tm.connection_requests), len(solution.connection_map))
@@ -58,7 +57,7 @@ class TESolverTests(unittest.TestCase):
             for path in paths:
                 self.assertIsInstance(path, ConnectionPath)
 
-        self.assertEqual(6.0, value)
+        self.assertEqual(6.0, solution.cost)
 
     def test_lb_solve(self):
         graph = self.make_random_graph()
@@ -68,8 +67,8 @@ class TESolverTests(unittest.TestCase):
         solver = TESolver(
             graph, tm, Constants.COST_FLAG_HOP, Constants.OBJECTIVE_LOAD_BALANCING
         )
-        solution, value = solver.solve()
-        print(f"Solution: {solution}, optimal: {value}")
+        solution = solver.solve()
+        print(f"Solution: {solution}")
 
         # Check that there's a solution for each request.
         self.assertEqual(len(tm.connection_requests), len(solution.connection_map))
@@ -82,7 +81,7 @@ class TESolverTests(unittest.TestCase):
             for path in paths:
                 self.assertIsInstance(path, ConnectionPath)
 
-        self.assertEqual(1.851, round(value, 3))
+        self.assertEqual(1.851, round(solution.cost, 3))
 
     def test_mc_solve_more_connections_than_nodes(self):
         graph = self.make_random_graph(num_nodes=10)
@@ -91,14 +90,13 @@ class TESolverTests(unittest.TestCase):
         tm = self.make_random_traffic_matrix(num_nodes=10, num_connections=20)
         print(f"tm: {tm}")
 
-        solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
-        solution, value = solver.solve()
-        print(f"Solution: {solution}, optimal: {value}")
+        solution = TESolver(graph, tm, Constants.COST_FLAG_HOP).solve()
+        print(f"Solution: {solution}")
 
         # The above doesn't seem to find a solution, but hey, at least
         # we exercised one more code path without any crashes.
-        self.assertIs(solution, None)
-        self.assertEqual(value, 0.0)
+        self.assertIs(solution.connection_map, None)
+        self.assertEqual(solution.cost, 0.0)
 
     def test_mc_solve_5(self):
         edge_list_file = TEST_DATA_DIR.joinpath("test_five_node_topology.txt")
@@ -117,9 +115,8 @@ class TESolverTests(unittest.TestCase):
         with open(traffic_matrix_file) as fp:
             tm = TrafficMatrix.from_dict(json.load(fp))
 
-        solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
-        solution, value = solver.solve()
-        print(f"Solution: {solution}, optimal: {value}")
+        solution = TESolver(graph, tm, Constants.COST_FLAG_HOP).solve()
+        print(f"Solution: {solution}")
 
         # Check that there's a solution for each request.
         self.assertEqual(len(tm.connection_requests), len(solution.connection_map))
@@ -132,7 +129,7 @@ class TESolverTests(unittest.TestCase):
             for path in paths:
                 self.assertIsInstance(path, ConnectionPath)
 
-        self.assertEqual(7.0, value)
+        self.assertEqual(7.0, solution.cost)
 
     @unittest.skipIf(not can_read_dot_file(), reason="Can't read dot file")
     def test_mc_solve_geant2012(self):
@@ -147,10 +144,8 @@ class TESolverTests(unittest.TestCase):
 
         self.assertNotEqual(tm, None, "Could not read connection file")
 
-        solver = TESolver(graph, tm, Constants.COST_FLAG_HOP)
-        solution, value = solver.solve()
-
-        print(f"Solution: {solution}, optimal: {value}")
+        solution = TESolver(graph, tm, Constants.COST_FLAG_HOP).solve()
+        print(f"Solution: {solution}")
 
 
 if __name__ == "__main__":

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -3,12 +3,7 @@ import unittest
 
 import matplotlib.pyplot as plt
 import networkx as nx
-from networkx import Graph, MultiGraph
 
-from sdx.datamodel.parsing.exceptions import DataModelException
-from sdx.datamodel.parsing.topologyhandler import TopologyHandler
-from sdx.datamodel.validation.topologyvalidator import TopologyValidator
-from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.pce.topology.manager import TopologyManager
 
 
@@ -20,7 +15,7 @@ class TopologyGrpahTests(unittest.TestCase):
     TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath("data")
     TOPOLOGY_FILE_AMLIGHT = TEST_DATA_DIR.joinpath("amlight.json")
     TOPOLOGY_FILE_AMLIGHT_IMG = TEST_DATA_DIR.joinpath("amlight.png")
-    
+
     def setUp(self):
         pass
 
@@ -29,20 +24,20 @@ class TopologyGrpahTests(unittest.TestCase):
 
     def test_generate_graph(self):
         print("Test Topology Graph")
-        
+
         topology_manager = TopologyManager()
         topology_handler = topology_manager.topology_handler
 
         topology_handler.topology_file_name(self.TOPOLOGY_FILE_AMLIGHT)
         topology_handler.import_topology()
         topology_manager.set_topology(topology_handler.get_topology())
-        
+
         graph = topology_manager.generate_graph()
 
         self.assertIsInstance(graph, nx.Graph)
 
         # Seed for reproducible layout
         # pos = nx.spring_layout(graph, seed=225)
-        
+
         nx.draw(graph)
         plt.savefig(self.TOPOLOGY_FILE_AMLIGHT_IMG)

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -1,3 +1,4 @@
+import pathlib
 import unittest
 
 import matplotlib.pyplot as plt
@@ -10,30 +11,38 @@ from sdx.datamodel.validation.topologyvalidator import TopologyValidator
 from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.pce.topology.manager import TopologyManager
 
-TOPOLOGY_AMLIGHT = "./tests/data/amlight.json"
-TOPOLOGY_SAX = "./tests/data/sax.json"
-TOPOLOGY_ZAOXI = "./tests/data/zaoxi.json"
 
+class TopologyGrpahTests(unittest.TestCase):
+    """
+    Test graph generation.
+    """
 
-class TestTopologyGrpah(unittest.TestCase):
+    TEST_DATA_DIR = pathlib.Path(__file__).parent.joinpath("data")
+    TOPOLOGY_FILE_AMLIGHT = TEST_DATA_DIR.joinpath("amlight.json")
+    TOPOLOGY_FILE_AMLIGHT_IMG = TEST_DATA_DIR.joinpath("amlight.png")
+    
     def setUp(self):
-        self.manager = TopologyManager()  # noqa: E501
-        self.handler = self.manager.topology_handler
-        self.handler.topology_file_name(TOPOLOGY_AMLIGHT)
-        self.handler.import_topology()
-        self.manager.set_topology(self.handler.get_topology())
+        pass
 
     def tearDown(self):
         pass
 
-    def testGenerateGraph(self):
-        try:
-            print("Test Topology Graph")
-            graph = self.manager.generate_graph()
-            # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout
-            nx.draw(graph)
-            plt.savefig("./tests/data/amlight.png")
-        except DataModelException as e:
-            print(e)
-            return False
-        return True
+    def test_generate_graph(self):
+        print("Test Topology Graph")
+        
+        topology_manager = TopologyManager()
+        topology_handler = topology_manager.topology_handler
+
+        topology_handler.topology_file_name(self.TOPOLOGY_FILE_AMLIGHT)
+        topology_handler.import_topology()
+        topology_manager.set_topology(topology_handler.get_topology())
+        
+        graph = topology_manager.generate_graph()
+
+        self.assertIsInstance(graph, nx.Graph)
+
+        # Seed for reproducible layout
+        # pos = nx.spring_layout(graph, seed=225)
+        
+        nx.draw(graph)
+        plt.savefig(self.TOPOLOGY_FILE_AMLIGHT_IMG)

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -16,12 +16,6 @@ class TopologyGrpahTests(unittest.TestCase):
     TOPOLOGY_FILE_AMLIGHT = TEST_DATA_DIR.joinpath("amlight.json")
     TOPOLOGY_FILE_AMLIGHT_IMG = TEST_DATA_DIR.joinpath("amlight.png")
 
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
     def test_generate_graph(self):
         print("Test Topology Graph")
 

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -1,0 +1,40 @@
+import unittest
+
+from networkx import MultiGraph, Graph
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from sdx.datamodel.validation.topologyvalidator import TopologyValidator
+from sdx.datamodel.parsing.topologyhandler import TopologyHandler
+from sdx.datamodel.topologymanager.manager import TopologyManager
+from sdx.datamodel.topologymanager.grenmlconverter import GrenmlConverter
+from sdx.datamodel.parsing.exceptions import DataModelException
+
+
+TOPOLOGY_AMLIGHT = "./tests/data/amlight.json"
+TOPOLOGY_SAX = "./tests/data/sax.json"
+TOPOLOGY_ZAOXI = "./tests/data/zaoxi.json"
+
+
+class TestTopologyGrpah(unittest.TestCase):
+    def setUp(self):
+        self.manager = TopologyManager()  # noqa: E501
+        self.handler = self.manager.handler
+        self.handler.topology_file_name(TOPOLOGY_AMLIGHT)
+        self.handler.import_topology()
+        self.manager.set_topology(self.handler.get_topology())
+
+    def tearDown(self):
+        pass
+
+    def testGenerateGraph(self):
+        try:
+            print("Test Topology Graph")
+            graph = self.manager.generate_graph()
+            # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout
+            nx.draw(graph)
+            plt.savefig("./tests/data/amlight.png")
+        except DataModelException as e:
+            print(e)
+            return False
+        return True

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -1,15 +1,14 @@
 import unittest
 
-from networkx import MultiGraph, Graph
 import matplotlib.pyplot as plt
 import networkx as nx
+from networkx import Graph, MultiGraph
 
-from sdx.datamodel.validation.topologyvalidator import TopologyValidator
-from sdx.datamodel.parsing.topologyhandler import TopologyHandler
-from sdx.pce.topology.manager import TopologyManager
-from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.datamodel.parsing.exceptions import DataModelException
-
+from sdx.datamodel.parsing.topologyhandler import TopologyHandler
+from sdx.datamodel.validation.topologyvalidator import TopologyValidator
+from sdx.pce.topology.grenmlconverter import GrenmlConverter
+from sdx.pce.topology.manager import TopologyManager
 
 TOPOLOGY_AMLIGHT = "./tests/data/amlight.json"
 TOPOLOGY_SAX = "./tests/data/sax.json"

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -6,8 +6,8 @@ import networkx as nx
 
 from sdx.datamodel.validation.topologyvalidator import TopologyValidator
 from sdx.datamodel.parsing.topologyhandler import TopologyHandler
-from sdx.datamodel.topologymanager.manager import TopologyManager
-from sdx.datamodel.topologymanager.grenmlconverter import GrenmlConverter
+from sdx.pce.topology.manager import TopologyManager
+from sdx.pce.topology.grenmlconverter import GrenmlConverter
 from sdx.datamodel.parsing.exceptions import DataModelException
 
 
@@ -19,7 +19,7 @@ TOPOLOGY_ZAOXI = "./tests/data/zaoxi.json"
 class TestTopologyGrpah(unittest.TestCase):
     def setUp(self):
         self.manager = TopologyManager()  # noqa: E501
-        self.handler = self.manager.handler
+        self.handler = self.manager.topology_handler
         self.handler.topology_file_name(TOPOLOGY_AMLIGHT)
         self.handler.import_topology()
         self.manager.set_topology(self.handler.get_topology())

--- a/tests/test_topology_grenmlconverter.py
+++ b/tests/test_topology_grenmlconverter.py
@@ -29,7 +29,9 @@ class GrenmlConverterTests(unittest.TestCase):
         manager.topology_handler.import_topology()
 
         print(f"Topology: {manager.topology_handler.topology}")
-        self.assertIsNotNone(manager.topology_handler.topology, "No topology could be read")
+        self.assertIsNotNone(
+            manager.topology_handler.topology, "No topology could be read"
+        )
 
         converter = GrenmlConverter(manager.topology_handler.topology)
         print(f"GrenmlConverter: {converter}")

--- a/tests/test_topology_grenmlconverter.py
+++ b/tests/test_topology_grenmlconverter.py
@@ -25,13 +25,13 @@ class GrenmlConverterTests(unittest.TestCase):
         # TODO: this does not raise errors when it should (such as
         # when the input file is not present). Make the necessary
         # change in datamodel's TopologyHandler class.
-        manager.handler.topology_file_name(self.AMLIGHT_TOPOLOGY_FILE)
-        manager.handler.import_topology()
+        manager.topology_handler.topology_file_name(self.AMLIGHT_TOPOLOGY_FILE)
+        manager.topology_handler.import_topology()
 
-        print(f"Topology: {manager.handler.topology}")
-        self.assertIsNotNone(manager.handler.topology, "No topology could be read")
+        print(f"Topology: {manager.topology_handler.topology}")
+        self.assertIsNotNone(manager.topology_handler.topology, "No topology could be read")
 
-        converter = GrenmlConverter(manager.handler.topology)
+        converter = GrenmlConverter(manager.topology_handler.topology)
         print(f"GrenmlConverter: {converter}")
         self.assertIsNotNone(converter, "Could not create GRENML converter")
 


### PR DESCRIPTION
Issue is #97.

The big change is that TEManager now has a `_generate_connection_breakdown_tm()` method which takes a [ConnectionSolution](https://github.com/atlanticwave-sdx/pce/blob/2679f11b9eff96f34ad5f8c25e4e3a79a2f98166/src/sdx/pce/models.py#L53) input and breaks it down.  Tests have been updated, and things seem to work with JSON topology data and JSON connection requests without crashes.

The old `generate_connection_breakdown()` is kept around as `_generate_connection_breakdown_old()`, for now.  If/when this PR gets merged, we can perhaps plan on removing that after some testing with sdx-controller.  We will need to discuss a plan.

Backward compatibility is maintained by a little crude hack:

https://github.com/atlanticwave-sdx/pce/blob/a45b6397f6ac839bc7f9501b1375b097d4be344a/src/sdx/pce/topology/temanager.py#L120-L126