### PR TITLE
Add domains in path breakdowns

### DIFF
--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -437,9 +437,8 @@ class TESolver:
                 #     f"i + count * len(inputmatrix[0]: {i + count * len(inputmatrix[0])}"
                 # )
 
-                bwconstraints[i][
-                    i + count * len(inputmatrix[0])
-                ] = request.required_bandwidth
+                k = i + count * len(inputmatrix[0])
+                bwconstraints[i][k] = request.required_bandwidth
                 count += 1
 
         return bwconstraints

--- a/src/sdx/pce/load_balancing/te_solver.py
+++ b/src/sdx/pce/load_balancing/te_solver.py
@@ -427,15 +427,15 @@ class TESolver:
             count = 0
 
             for request in request_list:
-                print(
-                    f"bwconstraints: {bwconstraints}, request: {request}, request_list: {request_list}"
-                )
-                print(
-                    f"i: {i}, count: {count} len(inputmatrix[0]): {len(inputmatrix[0])}, inputmatrix: {inputmatrix}"
-                )
-                print(
-                    f"i + count * len(inputmatrix[0]: {i + count * len(inputmatrix[0])}"
-                )
+                # print(
+                #     f"bwconstraints: {bwconstraints}, request: {request}, request_list: {request_list}"
+                # )
+                # print(
+                #     f"i: {i}, count: {count} len(inputmatrix[0]): {len(inputmatrix[0])}, inputmatrix: {inputmatrix}"
+                # )
+                # print(
+                #     f"i + count * len(inputmatrix[0]: {i + count * len(inputmatrix[0])}"
+                # )
 
                 bwconstraints[i][
                     i + count * len(inputmatrix[0])

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -88,11 +88,12 @@ class TopologyManager:
 
     def get_domain_name(self, node_id):
         domain_id = None
-        # print("len of topology_list:"+str(len(self.topology_list)))
-        for id, topology in self.topology_list.items():
+        # print(f"len of topology_list: {len(self.topology_list)}")
+        for topology_id, topology in self.topology_list.items():
             if topology.has_node_by_id(node_id):
-                domain_id = id
+                domain_id = topology_id
                 break
+
         return domain_id
 
     def generate_id(self):

--- a/src/sdx/pce/topology/manager.py
+++ b/src/sdx/pce/topology/manager.py
@@ -87,6 +87,15 @@ class TopologyManager:
         self.update_timestamp()
 
     def get_domain_name(self, node_id):
+        """
+        Find the topology ID associated with the given node ID.
+
+        A topology ID is expected to be of the format
+        "urn:ogf:network:sdx:topology:amlight.net", and from this, we
+        can find the domain name associated with the topology.
+
+        TODO: This function name may be a misnomer?
+        """
         domain_id = None
         # print(f"len of topology_list: {len(self.topology_list)}")
         for topology_id, topology in self.topology_list.items():

--- a/src/sdx/pce/topology/temanager.py
+++ b/src/sdx/pce/topology/temanager.py
@@ -29,9 +29,7 @@ class TEManager:
         self.topology_manager = TopologyManager()
         self.connection_handler = ConnectionHandler()
 
-        self.topology_manager.topology = (
-            self.topology_manager.get_handler().import_topology_data(topology_data)
-        )
+        self.topology_manager.add_topology(topology_data)
 
         print(f"TEManager: connection_data: {connection_data}")
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -85,6 +85,12 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsInstance(breakdown, dict)
         self.assertEqual(len(breakdown), 1)
 
+        # Make sure that breakdown contains domains as keys, and dicts
+        # as values.  The domain name is a little goofy, because the
+        # topology we have is goofy.
+        link = breakdown.get("urn:ogf:network:sdx")
+        self.assertIsInstance(link, dict)
+
     def test_connection_breakdown_two_similar_requests(self):
         # Solving and breaking down two similar connection requests.
         request = [

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -206,10 +206,26 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(graph)
         self.assertIsInstance(graph, nx.Graph)
 
-        connection = temanager.generate_connection_te()
-        print(f"connection request: {connection}")
-        self.assertIsNotNone(connection)
-        self.assertIsInstance(connection, TrafficMatrix)
+        tm = temanager.generate_connection_te()
+        print(f"traffic matrix: {tm}")
+        self.assertIsInstance(tm, TrafficMatrix)
+
+        self.assertIsInstance(tm.connection_requests, list)
+
+        for request in tm.connection_requests:
+            self.assertEqual(request.source, 1)
+            self.assertEqual(request.destination, 0)
+            self.assertEqual(request.required_bandwidth, 0)
+            self.assertEqual(request.required_latency, 0)
+
+        solver = TESolver(graph, tm)
+        self.assertIsNotNone(solver)
+
+        # Solver will fail to find a solution here.
+        solution = solver.solve()
+        print(f"Solution to tm {tm}: {solution}")
+        self.assertIsNone(solution.connection_map, None)
+        self.assertEqual(solution.cost, 0.0)
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -135,7 +135,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(breakdown)
         self.assertIsInstance(breakdown, dict)
-        self.assertEqual(len(breakdown), 2)
+        self.assertEqual(len(breakdown), 1)
 
     def test_connection_breakdown_some_input(self):
         # The set of requests below should fail to find a solution,


### PR DESCRIPTION
Issue is #110.

Before, breakdown used to be like mentioned in the issue.  Now it is like:

```
{
    "urn:ogf:network:sdx:topology:sax.net": {
        "ingress_port": {
            "id": "urn:ogf:network:sdx:port:zaoxi:A1:2",
            "name": "Novi100:2",
            "short_name": null,
            "node": null,
            "label_range": null,
            "status": null,
            "state": null,
            "private_attributes": null
        },
        "egress_port": {
            "id": "urn:ogf:network:sdx:port:sax:B2:4",
            "label_range": [
                "100-200",
                "10001"
            ],
            "name": "Novi02:4",
            "node": "urn:ogf:network:sdx:node:sax:B2",
            "short_name": "B2:3",
            "status": "up"
        }
    }
}
```

The critical change is the line where TEManager adds topology the right way, so that `TEManager.topology_manager.topology_list` is correctly populated, so that `TEManager.topology_manager.get_domain_name()` returns the domain name instead of `None`.  The rest is mostly noise from testing.