### PR TITLE
Multi-domain path breakdown investigation

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,8 +14,8 @@ class TestData:
 
     TOPOLOGY_FILE_AMLIGHT_IMG = TOPOLOGY_DATA_DIR / "amlight.png"
 
-    CONNECTION_REQ_AMLIGHT_SAX = TEST_DATA_DIR / "test_request.json"
-    CONNECTION_REQ_FILE = TEST_DATA_DIR / "test_request_amlight.json"
+    CONNECTION_REQ = TEST_DATA_DIR / "test_request.json"
+    CONNECTION_REQ_AMLIGHT = TEST_DATA_DIR / "test_request_amlight.json"
 
     TOPOLOGY_FILE_SAX_2 = TEST_DATA_DIR / "sax-2.json"
     CONNECTION_REQ_FILE_SAX_2_INVALID = TEST_DATA_DIR / "sax-2-request-invalid.json"

--- a/tests/data/test_request.json
+++ b/tests/data/test_request.json
@@ -3,8 +3,8 @@
     "name": "AMLight",
     "start_time": "2000-01-23T04:56:07.000Z",
     "end_time": "2000-01-23T04:56:07.000Z",
-    "bandwidth_required": 100,
-    "latency_required": 20,
+    "bandwidth_required": 50,
+    "latency_required": 100,
     "egress_port":
     {
         "id": "urn:sdx:port:amlight.net:A1:1",

--- a/tests/data/test_request.json
+++ b/tests/data/test_request.json
@@ -3,16 +3,20 @@
     "name": "AMLight",
     "start_time": "2000-01-23T04:56:07.000Z",
     "end_time": "2000-01-23T04:56:07.000Z",
-    "bandwidth_required": 50,
-    "latency_required": 100,
+    "bandwidth_required": 10,
+    "latency_required": 300,
     "egress_port":
     {
         "id": "urn:sdx:port:amlight.net:A1:1",
-        "name": "Novi100:1"
+        "name": "Novi100:1",
+        "node": "urn:sdx:node:amlight.net:A1",
+        "status": "up"
     },
     "ingress_port":
     {
         "id": "urn:ogf:network:sdx:port:zaoxi:A1:2",
-        "name": "Novi100:2"
+        "name": "Novi100:2",
+        "node": "urn:ogf:network:sdx:node:zaoxi:A1",
+        "status": "up"
     }
 }

--- a/tests/data/topologies/amlight.json
+++ b/tests/data/topologies/amlight.json
@@ -3,7 +3,7 @@
     "name": "AmLight-OXP",
     "model_version":"1.0.0",
     "time_stamp": "2000-01-23T04:56:07+00:00",
-    "version": 1.0,
+    "version": 1,
     "links": [
       {
         "availability": 56.37376656633328,

--- a/tests/data/topologies/sax.json
+++ b/tests/data/topologies/sax.json
@@ -2,7 +2,7 @@
   "id": "urn:ogf:network:sdx:topology:sax.net",
   "name": "SAX-OXP",
   "time_stamp": "2000-01-23T04:56:07+00:00",
-  "version": 1.0,
+  "version": 1,
   "model_version":"1.0.0",
   "links": [
     {

--- a/tests/data/topologies/zaoxi.json
+++ b/tests/data/topologies/zaoxi.json
@@ -2,7 +2,7 @@
   "id": "urn:ogf:network:sdx:topology:zaoxi.net",
   "name": "ZAOXI-OXP",
   "time_stamp": "2000-01-23T04:56:07+00:00",
-  "version": 1.0,
+  "version": 1,
   "model_version":"1.0.0",
   "links": [
     {

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -26,7 +26,7 @@ class TEManagerTests(unittest.TestCase):
         with open(TestData.TOPOLOGY_FILE_AMLIGHT, "r", encoding="utf-8") as fp:
             topology_data = json.load(fp)
 
-        with open(TestData.CONNECTION_REQ_FILE, "r", encoding="utf-8") as fp:
+        with open(TestData.CONNECTION_REQ_AMLIGHT, "r", encoding="utf-8") as fp:
             connection_data = json.load(fp)
 
         self.temanager = TEManager(topology_data, connection_data)
@@ -297,7 +297,7 @@ class TEManagerTests(unittest.TestCase):
 
         TODO: doesn't work as expected yet; see note at the bottom.
         """
-        connection_request = json.loads(TestData.CONNECTION_REQ_AMLIGHT_SAX.read_text())
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")
 
         temanager = TEManager(topology_data=None, connection_data=connection_request)
@@ -341,7 +341,7 @@ class TEManagerTests(unittest.TestCase):
         Solve with the "merged" topology of amlight, sax, and zaoxi.
         """
 
-        connection_request = json.loads(TestData.CONNECTION_REQ_AMLIGHT_SAX.read_text())
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")
 
         topology_data = json.loads(TestData.TOPOLOGY_FILE_SDX.read_text())

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -333,6 +333,41 @@ class TEManagerTests(unittest.TestCase):
         # See https://github.com/atlanticwave-sdx/pce/issues/114
         self.assertIsNone(solution.connection_map)
 
+    def test_connection_amlight_to_zaoxi_with_merged_topology(self):
+        """
+        Solve with the "merged" topology of amlight, sax, and zaoxi.
+        """
+
+        connection_request = json.loads(TestData.CONNECTION_REQ_AMLIGHT_SAX.read_text())
+        print(f"connection_request: {connection_request}")
+
+        topology_data = json.loads(TestData.TOPOLOGY_FILE_SDX.read_text())
+        print(f"topology_data: {topology_data}")
+
+        temanager = TEManager(
+            topology_data=topology_data, connection_data=connection_request
+        )
+
+        graph = temanager.generate_graph_te()
+        traffic_matrix = temanager.generate_connection_te()
+
+        print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
+
+        self.assertIsNotNone(graph)
+        self.assertIsNotNone(traffic_matrix)
+
+        for request in traffic_matrix.connection_requests:
+            print(
+                f"Connectivity for {request}: "
+                f"{temanager.graph_node_connectivity(request.source, request.destination)}"
+            )
+
+        solution = TESolver(graph, traffic_matrix).solve()
+        print(f"TESolver result: {solution}")
+
+        # This hopefully should find a solution.
+        self.assertIsNotNone(solution.connection_map)
+
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()
         tm = self.temanager.generate_connection_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -315,14 +315,14 @@ class TEManagerTests(unittest.TestCase):
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
+        self.assertIsNotNone(graph)
+        self.assertIsNotNone(traffic_matrix)
+
         for request in traffic_matrix.connection_requests:
             print(
                 f"Connectivity for {request}: "
                 f"{temanager.graph_node_connectivity(request.source, request.destination)}"
             )
-
-        self.assertIsNotNone(graph)
-        self.assertIsNotNone(traffic_matrix)
 
         solution = TESolver(graph, traffic_matrix).solve()
         print(f"TESolver result: {solution}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -336,6 +336,7 @@ class TEManagerTests(unittest.TestCase):
         breakdown = temanager.generate_connection_breakdown(solution)
         print(f"breakdown: {json.dumps(breakdown)}")
 
+
     def test_connection_amlight_to_zaoxi_with_merged_topology(self):
         """
         Solve with the "merged" topology of amlight, sax, and zaoxi.
@@ -373,6 +374,10 @@ class TEManagerTests(unittest.TestCase):
 
         breakdown = temanager.generate_connection_breakdown(solution)
         print(f"breakdown: {json.dumps(breakdown)}")
+
+        # Note that the "domain" key is wrong in the results when we
+        # initialize TEManager with a merged topology.
+        self.assertIsNotNone(breakdown.get("urn:ogf:network:sdx"))
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -368,6 +368,9 @@ class TEManagerTests(unittest.TestCase):
         # This hopefully should find a solution.
         self.assertIsNotNone(solution.connection_map)
 
+        breakdown = temanager.generate_connection_breakdown(solution)
+        print(f"breakdown: {json.dumps(breakdown)}")
+
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()
         tm = self.temanager.generate_connection_te()

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -318,11 +318,8 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(graph)
         self.assertIsNotNone(traffic_matrix)
 
-        for request in traffic_matrix.connection_requests:
-            print(
-                f"Connectivity for {request}: "
-                f"{temanager.graph_node_connectivity(request.source, request.destination)}"
-            )
+        conn = temanager.requests_connectivity(traffic_matrix)
+        print(f"Graph connectivity: {conn}")
 
         solution = TESolver(graph, traffic_matrix).solve()
         print(f"TESolver result: {solution}")
@@ -366,11 +363,8 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(graph)
         self.assertIsNotNone(traffic_matrix)
 
-        for request in traffic_matrix.connection_requests:
-            print(
-                f"Connectivity for {request}: "
-                f"{temanager.graph_node_connectivity(request.source, request.destination)}"
-            )
+        conn = temanager.requests_connectivity(traffic_matrix)
+        print(f"Graph connectivity: {conn}")
 
         solution = TESolver(graph, traffic_matrix).solve()
         print(f"TESolver result: {solution}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -336,6 +336,12 @@ class TEManagerTests(unittest.TestCase):
         breakdown = temanager.generate_connection_breakdown(solution)
         print(f"breakdown: {json.dumps(breakdown)}")
 
+        # Note that the "domain" key is correct in the breakdown
+        # result when we initialize TEManager with None for topology,
+        # and later add individual topologies with add_topology().
+        self.assertIsNotNone(breakdown.get("urn:ogf:network:sdx:topology:zaoxi.net"))
+        self.assertIsNotNone(breakdown.get("urn:ogf:network:sdx:topology:sax.net"))
+        self.assertIsNotNone(breakdown.get("urn:ogf:network:sdx:topology:amlight.net"))
 
     def test_connection_amlight_to_zaoxi_with_merged_topology(self):
         """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -337,6 +337,10 @@ class TEManagerTests(unittest.TestCase):
     def test_connection_amlight_to_zaoxi_with_merged_topology(self):
         """
         Solve with the "merged" topology of amlight, sax, and zaoxi.
+
+        Note that this does not work as it probably should -- when we
+        have a merged topology, nodes do not resolve to correct
+        domains.
         """
 
         connection_request = json.loads(TestData.CONNECTION_REQ.read_text())

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -331,7 +331,10 @@ class TEManagerTests(unittest.TestCase):
         # request evidently used to work prior to PCE refactoring.
         #
         # See https://github.com/atlanticwave-sdx/pce/issues/114
-        self.assertIsNone(solution.connection_map)
+        self.assertIsNotNone(solution.connection_map)
+
+        breakdown = temanager.generate_connection_breakdown(solution)
+        print(f"breakdown: {json.dumps(breakdown)}")
 
     def test_connection_amlight_to_zaoxi_with_merged_topology(self):
         """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -294,8 +294,6 @@ class TEManagerTests(unittest.TestCase):
     def test_connection_amlight_to_zaoxi(self):
         """
         Exercise a connection request between Amlight and Zaoxi.
-
-        TODO: doesn't work as expected yet; see note at the bottom.
         """
         connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -315,6 +315,12 @@ class TEManagerTests(unittest.TestCase):
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
+        for request in traffic_matrix.connection_requests:
+            print(
+                f"Connectivity for {request}: "
+                f"{temanager.graph_node_connectivity(request.source, request.destination)}"
+            )
+
         self.assertIsNotNone(graph)
         self.assertIsNotNone(traffic_matrix)
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -324,10 +324,6 @@ class TEManagerTests(unittest.TestCase):
         solution = TESolver(graph, traffic_matrix).solve()
         print(f"TESolver result: {solution}")
 
-        # TODO: why can't we find a solution for this now?  This test
-        # request evidently used to work prior to PCE refactoring.
-        #
-        # See https://github.com/atlanticwave-sdx/pce/issues/114
         self.assertIsNotNone(solution.connection_map)
 
         breakdown = temanager.generate_connection_breakdown(solution)


### PR DESCRIPTION
Issue is #114.  Changes:

- Every topology version has been corrected to be an integer (1 instead of 1.0). This way they will pass validation by connexion when we do a `POST /topology` at sdx-lc.
- The file `test_request.json` has been updated, to be consistent with [the one in sdx-controller](https://github.com/atlanticwave-sdx/sdx-controller/blob/main/tests/data/test_request.json).
- Updated a test (`test_connection_amlight_to_zaoxi`) to use the above test request.
- Added a test (`test_connection_amlight_to_zaoxi_with_merged_topology`) for to demonstrate that TEManager will resolve a node to the incorrected domain, when using the "merged" topology.
