### PR TITLE
Bump up datamodel requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     ortools
     prtpy
     dataclasses-json
-    sdxdatamodel @ git+https://github.com/atlanticwave-sdx/datamodel@1.0.1.dev3
+    sdxdatamodel @ git+https://github.com/atlanticwave-sdx/datamodel@2.0.0
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Small change, because of #118.  We will need to tag pce 2.0.1 and use that in sdx-controller.