### PR TITLE
Add link property checks

### DIFF
--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -30,7 +30,7 @@ class TopologyManager:
         self.topology_handler = TopologyHandler()
 
         self.topology = None
-        self.topology_list = {}
+        self._topology_map = {}
         self._port_map = {}  # {port, link}
 
         self.num_interdomain_link = 0
@@ -55,12 +55,12 @@ class TopologyManager:
 
     def clear_topology(self):
         self.topology = None
-        self.topology_list = {}
+        self._topology_map = {}
         self._port_map = {}
 
     def add_topology(self, data):
         topology = self.topology_handler.import_topology_data(data)
-        self.topology_list[topology.id] = topology
+        self._topology_map[topology.id] = topology
 
         if self.topology is None:
             self.topology = copy.deepcopy(topology)
@@ -103,8 +103,8 @@ class TopologyManager:
         TODO: This function name may be a misnomer?
         """
         domain_id = None
-        # print(f"len of topology_list: {len(self.topology_list)}")
-        for topology_id, topology in self.topology_list.items():
+        # print(f"len of topology_list: {len(self._topology_map)}")
+        for topology_id, topology in self._topology_map.items():
             if topology.has_node_by_id(node_id):
                 domain_id = topology_id
                 break
@@ -117,7 +117,7 @@ class TopologyManager:
         return id
 
     def remove_topology(self, topology_id):
-        self.topology_list.pop(topology_id, None)
+        self._topology_map.pop(topology_id, None)
         self.update_version(False)
         self.update_timestamp()
 
@@ -125,7 +125,7 @@ class TopologyManager:
         # likely adding new inter-domain links
         update_handler = TopologyHandler()
         topology = update_handler.import_topology_data(data)
-        self.topology_list[topology.id] = topology
+        self._topology_map[topology.id] = topology
 
         # Nodes.
         nodes = topology.get_nodes()
@@ -261,7 +261,7 @@ class TopologyManager:
     # on performance properties for now
     def update_link_property(self, link_id, property, value):
         # 1. update the individual topology
-        for id, topology in self.topology_list.items():
+        for id, topology in self._topology_map.items():
             links = topology.get_links()
             for link in links:
                 print(link.id + ";" + id)

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -25,9 +25,17 @@ class TopologyManager:
     """
 
     def __init__(self):
+        # The merged "super" topology of topologies of different
+        # domains, with inter-domain links between them computed.
         self._topology = None
+
+        # Mapping from topology ID to topology.
         self._topology_map = {}
-        self._port_map = {}  # {port, link}
+
+        # Mapping from port ID to link.
+        self._port_map = {}
+
+        # Number of interdomain links we computed.
         self._num_interdomain_link = 0
 
     def topology_id(self, id):

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -27,16 +27,11 @@ class TopologyManager:
     def __init__(self):
         super().__init__()
 
-        self.topology_handler = TopologyHandler()
-
         self._topology = None
         self._topology_map = {}
         self._port_map = {}  # {port, link}
 
         self.num_interdomain_link = 0
-
-    def get_handler(self):
-        return self.topology_handler
 
     def topology_id(self, id):
         self._topology._id(id)
@@ -59,7 +54,7 @@ class TopologyManager:
         self._port_map = {}
 
     def add_topology(self, data):
-        topology = self.topology_handler.import_topology_data(data)
+        topology = TopologyHandler().import_topology_data(data)
         self._topology_map[topology.id] = topology
 
         if self._topology is None:

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -25,8 +25,6 @@ class TopologyManager:
     """
 
     def __init__(self):
-        super().__init__()
-
         self._topology = None
         self._topology_map = {}
         self._port_map = {}  # {port, link}

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -28,8 +28,7 @@ class TopologyManager:
         self._topology = None
         self._topology_map = {}
         self._port_map = {}  # {port, link}
-
-        self.num_interdomain_link = 0
+        self._num_interdomain_link = 0
 
     def topology_id(self, id):
         self._topology._id(id)
@@ -68,8 +67,8 @@ class TopologyManager:
                     self._port_map[port["id"]] = link
         else:
             # check the inter-domain links first.
-            self.num_interdomain_link += self.inter_domain_check(topology)
-            if self.num_interdomain_link == 0:
+            self._num_interdomain_link += self.inter_domain_check(topology)
+            if self._num_interdomain_link == 0:
                 print(f"Warning: no interdomain links detected in {topology.id}!")
 
             # Nodes

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -102,7 +102,7 @@ class TEManager:
         #     port_list=self.topology_manager.port_list,
         # )
 
-    def _update_vlan_tags_table(self, domain_name, port_list):
+    def _update_vlan_tags_table(self, domain_name: str, port_list: dict):
         """
         Update VLAN tags table.
         """

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -129,7 +129,7 @@ class TEManager:
                 if label_range is None:
                     continue
 
-                # assert label_range is not None, "label_range is None"
+                assert label_range is not None, "label_range is None"
 
                 # label_range is of the form ['100-200', '1000']; let
                 # us expand it.  Would have been ideal if this was

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -122,6 +122,17 @@ class TEManager:
                 # print(f"port_id: {port_id}, port_id_inner: {port_id_inner}")
                 # assert port_id == port_id_inner
 
+                # Collect all port IDs in this link.
+                link_port_ids = [x.get("id") for x in link.ports]
+
+                # Do some error checks.
+                link_port_count = len(link_port_ids)
+                if link_port_count != 2:
+                    raise ValueError(f"Link has {link_port_count} ports, not 2")
+
+                if port_id not in link_port_ids:
+                    raise ValueError(f"port {port_id} not in {link_port_ids}")
+
                 label_range = port.get("label_range")
 
                 # TODO: why is label_range sometimes None, and what to

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -138,9 +138,8 @@ class TEManager:
                 # TODO: why is label_range sometimes None, and what to
                 # do when that happens?
                 if label_range is None:
+                    print(f"label_range on {port.get('id')} is None")
                     continue
-
-                assert label_range is not None, "label_range is None"
 
                 # label_range is of the form ['100-200', '1000']; let
                 # us expand it.  Would have been ideal if this was

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -181,8 +181,10 @@ class TEManager:
             f"egress_port.id: {egress_port.id}"
         )
 
-        ingress_node = self.topology_manager.topology.get_node_by_port(ingress_port.id)
-        egress_node = self.topology_manager.topology.get_node_by_port(egress_port.id)
+        topology = self.topology_manager.get_topology()
+
+        ingress_node = topology.get_node_by_port(ingress_port.id)
+        egress_node = topology.get_node_by_port(egress_port.id)
 
         if ingress_node is None:
             print(f"No ingress node was found for ingress port ID '{ingress_port.id}'")
@@ -326,7 +328,9 @@ class TEManager:
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link.source]["id"]
                 n2 = self.graph.nodes[last_link.destination]["id"]
-                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
+                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
+                    n1, n2
+                )
                 i_port = self.connection.ingress_port.to_dict()
                 e_port = p1
                 next_i = p2
@@ -337,7 +341,9 @@ class TEManager:
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link.source]["id"]
                 n2 = self.graph.nodes[last_link.destination]["id"]
-                n1, p1, n2, p2 = self.topology_manager.topology.get_port_by_link(n1, n2)
+                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
+                    n1, n2
+                )
                 i_port = next_i
                 e_port = p1
                 next_i = p2

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -17,6 +17,7 @@ from sdx_pce.models import (
     VlanTaggedPort,
 )
 from sdx_pce.topology.manager import TopologyManager
+from sdx_pce.utils.exceptions import ValidationError
 
 
 class TEManager:
@@ -119,10 +120,10 @@ class TEManager:
                 link_port_count = len(link_port_ids)
 
                 if link_port_count != 2:
-                    raise ValueError(f"Link has {link_port_count} ports, not 2")
+                    raise ValidationError(f"Link has {link_port_count} ports, not 2")
 
                 if port_id not in link_port_ids:
-                    raise ValueError(f"port {port_id} not in {link_port_ids}")
+                    raise ValidationError(f"port {port_id} not in {link_port_ids}")
 
                 label_range = port.get("label_range")
 
@@ -160,7 +161,7 @@ class TEManager:
         case, we return [100].
         """
         if not isinstance(label, str):
-            raise ValueError("Label must be a string.")
+            raise ValidationError("Label must be a string.")
 
         parts = label.split("-")
         start = int(parts[0])

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -111,7 +111,8 @@ class TEManager:
         for port_id, link in port_list.items():
             # TODO: port here seems to be a dict, not sdx_datamodel.models.Port
             for port in link.ports:
-                # Collect all port IDs in this link.
+                # Collect all port IDs in this link.  Each link should
+                # have two ports.
                 link_port_ids = [x.get("id") for x in link.ports]
 
                 # Do some error checks.

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -111,22 +111,12 @@ class TEManager:
         for port_id, link in port_list.items():
             # TODO: port here seems to be a dict, not sdx_datamodel.models.Port
             for port in link.ports:
-                # TODO: sometimes port_id and "inner" port_id below
-                # can be different.  Why?  For example, port_id of
-                # urn:sdx:port:amlight.net:B1:2 and port_id_inner of
-                # urn:sdx:port:amlight.net:B2:2.
-                #
-                # See https://github.com/atlanticwave-sdx_pce/issues/124
-                #
-                # port_id_inner = port.get("id")
-                # print(f"port_id: {port_id}, port_id_inner: {port_id_inner}")
-                # assert port_id == port_id_inner
-
                 # Collect all port IDs in this link.
                 link_port_ids = [x.get("id") for x in link.ports]
 
                 # Do some error checks.
                 link_port_count = len(link_port_ids)
+
                 if link_port_count != 2:
                     raise ValueError(f"Link has {link_port_count} ports, not 2")
 

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -55,7 +55,7 @@ class TEManager:
             self.graph = self.generate_graph_te()
             self._update_vlan_tags_table(
                 domain_name=topology_data.get("id"),
-                port_map=self.topology_manager.port_list,
+                port_map=self.topology_manager.get_port_map(),
             )
         else:
             self.graph = None
@@ -82,7 +82,7 @@ class TEManager:
         # attached to links.
         self._update_vlan_tags_table(
             domain_name=topology_data.get("id"),
-            port_map=self.topology_manager.port_list,
+            port_map=self.topology_manager.get_port_map(),
         )
 
     def update_topology(self, topology_data: dict):

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -55,7 +55,7 @@ class TEManager:
             self.graph = self.generate_graph_te()
             self._update_vlan_tags_table(
                 domain_name=topology_data.get("id"),
-                port_list=self.topology_manager.port_list,
+                port_map=self.topology_manager.port_list,
             )
         else:
             self.graph = None
@@ -82,7 +82,7 @@ class TEManager:
         # attached to links.
         self._update_vlan_tags_table(
             domain_name=topology_data.get("id"),
-            port_list=self.topology_manager.port_list,
+            port_map=self.topology_manager.port_list,
         )
 
     def update_topology(self, topology_data: dict):
@@ -102,13 +102,13 @@ class TEManager:
         #     port_list=self.topology_manager.port_list,
         # )
 
-    def _update_vlan_tags_table(self, domain_name: str, port_list: dict):
+    def _update_vlan_tags_table(self, domain_name: str, port_map: dict):
         """
         Update VLAN tags table.
         """
         self._vlan_tags_table[domain_name] = {}
 
-        for port_id, link in port_list.items():
+        for port_id, link in port_map.items():
             # TODO: port here seems to be a dict, not sdx_datamodel.models.Port
             for port in link.ports:
                 # Collect all port IDs in this link.  Each link should

--- a/src/sdx_pce/utils/exceptions.py
+++ b/src/sdx_pce/utils/exceptions.py
@@ -1,0 +1,7 @@
+class ValidationError(Exception):
+    """
+    A custom exception class to indicate errors.
+    """
+
+    def __init__(self, message):
+        super().__init__(message)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -155,7 +155,7 @@ class TEManagerTests(unittest.TestCase):
         solution = self._make_tm_and_solve(request)
 
         print(f"topology: {self.temanager.topology_manager.topology}")
-        print(f"topology_list: {self.temanager.topology_manager.topology_list}")
+        print(f"topology_list: {self.temanager.topology_manager._topology_map}")
 
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -154,7 +154,7 @@ class TEManagerTests(unittest.TestCase):
 
         solution = self._make_tm_and_solve(request)
 
-        print(f"topology: {self.temanager.topology_manager.topology}")
+        print(f"topology: {self.temanager.topology_manager.get_topology()}")
         # print(f"topology_list: {self.temanager.topology_manager._topology_map}")
 
         self.assertIsNotNone(solution.connection_map)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -155,7 +155,7 @@ class TEManagerTests(unittest.TestCase):
         solution = self._make_tm_and_solve(request)
 
         print(f"topology: {self.temanager.topology_manager.topology}")
-        print(f"topology_list: {self.temanager.topology_manager._topology_map}")
+        # print(f"topology_list: {self.temanager.topology_manager._topology_map}")
 
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)

--- a/tests/test_topology_graph.py
+++ b/tests/test_topology_graph.py
@@ -2,6 +2,7 @@ import unittest
 
 import matplotlib.pyplot as plt
 import networkx as nx
+from sdx_datamodel.parsing.topologyhandler import TopologyHandler
 
 from sdx_pce.topology.manager import TopologyManager
 
@@ -17,10 +18,9 @@ class TopologyGrpahTests(unittest.TestCase):
         """
         Write graph images of a given topology file.
         """
-        topology_manager = TopologyManager()
-        topology_handler = topology_manager.topology_handler
+        topology = TopologyHandler().import_topology(infile)
 
-        topology = topology_handler.import_topology(infile)
+        topology_manager = TopologyManager()
         topology_manager.set_topology(topology)
 
         graph = topology_manager.generate_graph()

--- a/tests/test_topology_grenmlconverter.py
+++ b/tests/test_topology_grenmlconverter.py
@@ -23,7 +23,7 @@ class GrenmlConverterTests(unittest.TestCase):
         pass
 
     def test_grenml_converter_amlight(self):
-        manager = TopologyManager()
+        TopologyManager()
 
         # TODO: this does not raise errors when it should (such as
         # when the input file is not present). Make the necessary

--- a/tests/test_topology_grenmlconverter.py
+++ b/tests/test_topology_grenmlconverter.py
@@ -1,5 +1,7 @@
 import unittest
 
+from sdx_datamodel.parsing.topologyhandler import TopologyHandler
+
 from sdx_pce.topology.grenmlconverter import GrenmlConverter
 from sdx_pce.topology.manager import TopologyManager
 
@@ -26,9 +28,7 @@ class GrenmlConverterTests(unittest.TestCase):
         # TODO: this does not raise errors when it should (such as
         # when the input file is not present). Make the necessary
         # change in datamodel's TopologyHandler class.
-        topology = manager.topology_handler.import_topology(
-            TestData.TOPOLOGY_FILE_AMLIGHT
-        )
+        topology = TopologyHandler().import_topology(TestData.TOPOLOGY_FILE_AMLIGHT)
 
         print(f"Topology: {topology}")
         self.assertIsNotNone(topology, "No topology could be read")

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -41,8 +41,8 @@ class TopologyManagerTests(unittest.TestCase):
 
         for topology_file in self.TOPOLOGY_FILE_LIST:
             print(f"Adding Topology file: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as infile:
-                self.topology_manager.add_topology(json.load(infile))
+            topology_data = json.loads(pathlib.Path(topology_file).read_text())
+            self.topology_manager.add_topology(topology_data)
 
         topology = self.topology_manager.get_topology()
 
@@ -60,8 +60,8 @@ class TopologyManagerTests(unittest.TestCase):
 
         for topology_file in self.TOPOLOGY_FILE_LIST_UPDATE:
             print(f"Updating topology: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as infile:
-                self.topology_manager.update_topology(json.load(infile))
+            topology_data = json.loads(pathlib.Path(topology_file).read_text())
+            self.topology_manager.add_topology(topology_data)
 
         topology = self.topology_manager.get_topology()
 
@@ -112,15 +112,15 @@ class TopologyManagerTests(unittest.TestCase):
     def test_link_property_update_json(self):
         print("Test Topology JSON Link Property Update!")
 
-        with open(self.TOPOLOGY_IN, "r", encoding="utf-8") as infile:
-            data = json.load(infile)
-            self.topology_manager.update_element_property_json(
-                data, "links", self.LINK_ID, "latency", 20
-            )
+        topology_data = json.loads(pathlib.Path(self.TOPOLOGY_IN).read_text())
 
-            self.assertIsInstance(data, dict)
+        self.topology_manager.update_element_property_json(
+            topology_data, "links", self.LINK_ID, "latency", 20
+        )
 
-            pathlib.Path(self.TOPOLOGY_OUT).write_text(json.dumps(data, indent=4))
+        self.assertIsInstance(topology_data, dict)
+
+        pathlib.Path(self.TOPOLOGY_OUT).write_text(json.dumps(topology_data, indent=4))
 
     def test_get_domain_name(self):
         """
@@ -128,8 +128,8 @@ class TopologyManagerTests(unittest.TestCase):
         """
         for topology_file in self.TOPOLOGY_FILE_LIST:
             print(f"Adding Topology file: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as infile:
-                self.topology_manager.add_topology(json.load(infile))
+            topology_data = json.loads(pathlib.Path(topology_file).read_text())
+            self.topology_manager.add_topology(topology_data)
 
         topology = self.topology_manager.get_topology()
 

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -43,11 +43,13 @@ class TopologyManagerTests(unittest.TestCase):
             with open(topology_file, "r", encoding="utf-8") as infile:
                 self.topology_manager.add_topology(json.load(infile))
 
-        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
+        topology = self.topology_manager.get_topology()
+
+        self.assertIsInstance(topology.to_dict(), dict)
 
         print(f"Writing result to {self.TOPOLOGY_OUT}")
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
+            json.dump(topology.to_dict(), outfile, indent=4)
 
     def test_update_topology(self):
         print("Test Topology Update!")
@@ -59,10 +61,12 @@ class TopologyManagerTests(unittest.TestCase):
             with open(topology_file, "r", encoding="utf-8") as infile:
                 self.topology_manager.update_topology(json.load(infile))
 
-        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
+        topology = self.topology_manager.get_topology()
+
+        self.assertIsInstance(topology.to_dict(), dict)
 
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
+            json.dump(topology.to_dict(), outfile, indent=4)
 
         graph = self.topology_manager.generate_graph()
         # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout
@@ -94,10 +98,12 @@ class TopologyManagerTests(unittest.TestCase):
         self.topology_manager.update_link_property(self.LINK_ID, "latency", 8)
         self.topology_manager.update_link_property(self.INTER_LINK_ID, "latency", 8)
 
-        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
+        topology = self.topology_manager.get_topology()
+
+        self.assertIsInstance(topology.to_dict(), dict)
 
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
+            json.dump(topology.to_dict(), outfile, indent=4)
 
     def test_link_property_update_json(self):
         print("Test Topology JSON Link Property Update!")

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import unittest
 
 import matplotlib.pyplot as plt
@@ -48,8 +49,9 @@ class TopologyManagerTests(unittest.TestCase):
         self.assertIsInstance(topology.to_dict(), dict)
 
         print(f"Writing result to {self.TOPOLOGY_OUT}")
-        with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(topology.to_dict(), outfile, indent=4)
+        pathlib.Path(self.TOPOLOGY_OUT).write_text(
+            json.dumps(topology.to_dict(), indent=4)
+        )
 
     def test_update_topology(self):
         print("Test Topology Update!")
@@ -65,8 +67,9 @@ class TopologyManagerTests(unittest.TestCase):
 
         self.assertIsInstance(topology.to_dict(), dict)
 
-        with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(topology.to_dict(), outfile, indent=4)
+        pathlib.Path(self.TOPOLOGY_OUT).write_text(
+            json.dumps(topology.to_dict(), indent=4)
+        )
 
         graph = self.topology_manager.generate_graph()
         # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout
@@ -102,8 +105,9 @@ class TopologyManagerTests(unittest.TestCase):
 
         self.assertIsInstance(topology.to_dict(), dict)
 
-        with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(topology.to_dict(), outfile, indent=4)
+        pathlib.Path(self.TOPOLOGY_OUT).write_text(
+            json.dumps(topology.to_dict(), indent=4)
+        )
 
     def test_link_property_update_json(self):
         print("Test Topology JSON Link Property Update!")
@@ -116,8 +120,7 @@ class TopologyManagerTests(unittest.TestCase):
 
             self.assertIsInstance(data, dict)
 
-            with open(self.TOPOLOGY_OUT, "w") as outfile:
-                json.dump(data, outfile, indent=4)
+            pathlib.Path(self.TOPOLOGY_OUT).write_text(json.dumps(data, indent=4))
 
     def test_get_domain_name(self):
         """

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -43,11 +43,11 @@ class TopologyManagerTests(unittest.TestCase):
             with open(topology_file, "r", encoding="utf-8") as infile:
                 self.topology_manager.add_topology(json.load(infile))
 
-        self.assertIsInstance(self.topology_manager.topology.to_dict(), dict)
+        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
 
         print(f"Writing result to {self.TOPOLOGY_OUT}")
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.topology.to_dict(), outfile, indent=4)
+            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
 
     def test_update_topology(self):
         print("Test Topology Update!")
@@ -59,10 +59,10 @@ class TopologyManagerTests(unittest.TestCase):
             with open(topology_file, "r", encoding="utf-8") as infile:
                 self.topology_manager.update_topology(json.load(infile))
 
-        self.assertIsInstance(self.topology_manager.topology.to_dict(), dict)
+        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
 
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.topology.to_dict(), outfile, indent=4)
+            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
 
         graph = self.topology_manager.generate_graph()
         # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout
@@ -94,10 +94,10 @@ class TopologyManagerTests(unittest.TestCase):
         self.topology_manager.update_link_property(self.LINK_ID, "latency", 8)
         self.topology_manager.update_link_property(self.INTER_LINK_ID, "latency", 8)
 
-        self.assertIsInstance(self.topology_manager.topology.to_dict(), dict)
+        self.assertIsInstance(self.topology_manager.get_topology().to_dict(), dict)
 
         with open(self.TOPOLOGY_OUT, "w") as outfile:
-            json.dump(self.topology_manager.topology.to_dict(), outfile, indent=4)
+            json.dump(self.topology_manager.get_topology().to_dict(), outfile, indent=4)
 
     def test_link_property_update_json(self):
         print("Test Topology JSON Link Property Update!")


### PR DESCRIPTION
Fixes #124.  The main change is here:

https://github.com/atlanticwave-sdx/pce/blob/7460cab1da0bee2c62f31cfc3583604e4b51ebe9/src/sdx_pce/topology/temanager.py#L115-L126

Basically validates that a link has the expected properties.  Other changes are basically some quality-of-life stuff that emerged when I started looking into this:

- Adds a `sdx_pce.utils.exceptions.ValidationError` exception class to indicate errors.
- Hides `TopologyManager` implementation details.  Mark variables with `_` prefix indicating that they are private, and they must be accessed with getter methods now.  I found the direct use of `TopologyManager` member variables confusing.
- Updates the tests accordingly.