### PR TITLE
Handle several connection requests in TEManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ details, the general usage is like this:
 from sdx_pce.load_balancing.te_solver import TESolver
 from sdx_pce.topology.temanager import TEManager
 
-temanager = TEManager(initial_topology, connection_request)
+temanager = TEManager(initial_topology)
 for topology in topologies:
     temanager.add_topology(topology)
     
 graph = temanager.generate_graph_te()
-traffic_matrix = temanager.generate_connection_te()
+traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
 solution = TESolver(graph, traffic_matrix).solve()
+
+breakdown = temanager.generate_connection_breakdown(solution)
+for domain, link in breakdown.items():
+    # publish(domain, link)
 ```
 
 Note that PCE requires two inputs: network topology and connection

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -323,18 +323,20 @@ class TEManager:
 
             if first:
                 first = False
-                i_port, _ = self._get_ports_by_link(links[0])
-                e_port, next_i = self._get_ports_by_link(links[-1])
+                # ingress port for this domain is on the first link.
+                ingress_port, _ = self._get_ports_by_link(links[0])
+                # egress port for this domain is on the last link.
+                egress_port, next_ingress_port = self._get_ports_by_link(links[-1])
             elif i == len(breakdown) - 1:
-                i_port = next_i
-                _, e_port = self._get_ports_by_link(links[-1])
+                ingress_port = next_ingress_port
+                _, egress_port = self._get_ports_by_link(links[-1])
             else:
-                i_port = next_i
-                e_port, next_i = self._get_ports_by_link(links[-1])
+                ingress_port = next_ingress_port
+                egress_port, next_ingress_port = self._get_ports_by_link(links[-1])
 
             segment = {}                
-            segment["ingress_port"] = i_port
-            segment["egress_port"] = e_port
+            segment["ingress_port"] = ingress_port
+            segment["egress_port"] = egress_port
             print(f"segment for {domain}: {segment}")
 
             domain_breakdown[domain] = segment.copy()

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -158,21 +158,21 @@ class TEManager:
 
         return list(range(start, stop))
 
-    def generate_connection_te(self, connection_request: dict) -> TrafficMatrix:
+    def generate_traffic_matrix(self, connection_request: dict) -> TrafficMatrix:
         """
         Generate a Traffic Matrix from the connection request we have.
         """
-        print(f"generate_connection_te: connection_request: {connection_request}")
+        print(f"generate_traffic_matrix: connection_request: {connection_request}")
 
         request = ConnectionHandler().import_connection_data(connection_request)
 
-        print(f"generate_connection_te: decoded request: {request}")
+        print(f"generate_traffic_matrix: decoded request: {request}")
 
         ingress_port = request.ingress_port
         egress_port = request.egress_port
 
         print(
-            f"generate_connection_te(), ports: "
+            f"generate_traffic_matrix, ports: "
             f"ingress_port.id: {ingress_port.id}, "
             f"egress_port.id: {egress_port.id}"
         )

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -323,18 +323,46 @@ class TEManager:
             segment = {}
             if first:
                 first = False
+
+                first_link = links[0]
+                first_link_node1 = self.graph.nodes[first_link.source]["id"]
+                first_link_node2 = self.graph.nodes[first_link.destination]["id"]
+                (
+                    _,
+                    first_link_port1,
+                    _,
+                    _,
+                ) = self.topology_manager.get_topology().get_port_by_link(
+                    first_link_node1, first_link_node2
+                )
+                print(f"First link, domain: {domain}, port1: {first_link_port1}")
+                i_port = first_link_port1
+
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link.source]["id"]
                 n2 = self.graph.nodes[last_link.destination]["id"]
                 n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
                     n1, n2
                 )
-                i_port = self.connection.ingress_port.to_dict()
+                print(
+                    f"Last link, domain: {domain}, n1 => {n1}, p1 => {p1}, n2 => {n2}, p2 => {p2}"
+                )
                 e_port = p1
                 next_i = p2
             elif i == len(breakdown) - 1:
                 i_port = next_i
-                e_port = self.connection.egress_port.to_dict()
+                # e_port = self.connection.egress_port.to_dict()
+                link = links[i]
+                n1 = self.graph.nodes[link.source]["id"]
+                n2 = self.graph.nodes[link.destination]["id"]
+                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
+                    n1, n2
+                )
+                print(
+                    f"Link #{i}, domain: {domain}, n1 => {n1}, p1 => {p1}, n2 => {n2}, p2 => {p2}"
+                )
+                e_port = p2
+                
             else:
                 last_link = links[-1]
                 n1 = self.graph.nodes[last_link.source]["id"]

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -318,6 +318,11 @@ class TEManager:
         i = 0
         domain_breakdown = {}
 
+        # TODO: using dict to represent a breakdown is dubious, and
+        # may lead to incorrect results.  Dicts are lexically ordered,
+        # and that may break some assumptions about the order in which
+        # we form and traverse the breakdown.
+
         for domain, links in breakdown.items():
             print(f"Creating domain_breakdown: domain: {domain}, links: {links}")
 

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -320,31 +320,26 @@ class TEManager:
 
         for domain, links in breakdown.items():
             print(f"Creating domain_breakdown: domain: {domain}, links: {links}")
-            segment = {}
+
             if first:
                 first = False
 
                 first_link = links[0]
-                p1, _ = self._get_ports_by_link(first_link)
-                i_port = p1
+                i_port, _ = self._get_ports_by_link(first_link)
 
                 last_link = links[-1]
-                p1, p2 = self._get_ports_by_link(last_link)
-                e_port = p1
-                next_i = p2
+                e_port, next_i = self._get_ports_by_link(last_link)
             elif i == len(breakdown) - 1:
                 i_port = next_i
                 last_link = links[-1]
-                p1, p2 = self._get_ports_by_link(last_link)
-                e_port = p2
+                _, e_port = self._get_ports_by_link(last_link)
             else:
                 last_link = links[-1]
-                p1, p2 = self._get_ports_by_link(last_link)
-
                 i_port = next_i
-                e_port = p1
-                next_i = p2
+                
+                e_port, next_i = self._get_ports_by_link(last_link)
 
+            segment = {}                
             segment["ingress_port"] = i_port
             segment["egress_port"] = e_port
             print(f"segment for {domain}: {segment}")

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -325,56 +325,30 @@ class TEManager:
                 first = False
 
                 first_link = links[0]
-                first_link_node1 = self.graph.nodes[first_link.source]["id"]
-                first_link_node2 = self.graph.nodes[first_link.destination]["id"]
-                (
-                    _,
-                    first_link_port1,
-                    _,
-                    _,
-                ) = self.topology_manager.get_topology().get_port_by_link(
-                    first_link_node1, first_link_node2
-                )
-                print(f"First link, domain: {domain}, port1: {first_link_port1}")
-                i_port = first_link_port1
+                p1, _ = self._get_ports_by_link(first_link)
+                i_port = p1
 
                 last_link = links[-1]
-                n1 = self.graph.nodes[last_link.source]["id"]
-                n2 = self.graph.nodes[last_link.destination]["id"]
-                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
-                    n1, n2
-                )
-                print(
-                    f"Last link, domain: {domain}, n1 => {n1}, p1 => {p1}, n2 => {n2}, p2 => {p2}"
-                )
+                p1, p2 = self._get_ports_by_link(last_link)
                 e_port = p1
                 next_i = p2
             elif i == len(breakdown) - 1:
                 i_port = next_i
-                # e_port = self.connection.egress_port.to_dict()
-                link = links[i]
-                n1 = self.graph.nodes[link.source]["id"]
-                n2 = self.graph.nodes[link.destination]["id"]
-                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
-                    n1, n2
-                )
-                print(
-                    f"Link #{i}, domain: {domain}, n1 => {n1}, p1 => {p1}, n2 => {n2}, p2 => {p2}"
-                )
+                last_link = links[-1]
+                p1, p2 = self._get_ports_by_link(last_link)
                 e_port = p2
-                
             else:
                 last_link = links[-1]
-                n1 = self.graph.nodes[last_link.source]["id"]
-                n2 = self.graph.nodes[last_link.destination]["id"]
-                n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
-                    n1, n2
-                )
+                p1, p2 = self._get_ports_by_link(last_link)
+
                 i_port = next_i
                 e_port = p1
                 next_i = p2
+
             segment["ingress_port"] = i_port
             segment["egress_port"] = e_port
+            print(f"segment for {domain}: {segment}")
+
             domain_breakdown[domain] = segment.copy()
             i = i + 1
 
@@ -392,6 +366,22 @@ class TEManager:
         # Return a dict containing VLAN-tagged breakdown in the
         # expected format.
         return tagged_breakdown.to_dict().get("breakdowns")
+
+    def _get_ports_by_link(self, link):
+        """
+        Given a link, find the ports associated with it.
+        """
+        node1 = self.graph.nodes[link.source]["id"]
+        node2 = self.graph.nodes[link.destination]["id"]
+
+        n1, p1, n2, p2 = self.topology_manager.get_topology().get_port_by_link(
+            node1, node2
+        )
+
+        assert n1 == node1
+        assert n2 == node2
+
+        return p1, p2
 
     """
     functions for vlan reservation.

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -34,11 +34,10 @@ class TEManager:
         - VLAN reservation and unreservation.
     """
 
-    def __init__(self, topology_data, connection_data):
+    def __init__(self, topology_data):
         super().__init__()
 
         self.topology_manager = TopologyManager()
-        self.connection_handler = ConnectionHandler()
 
         # A lock to safely perform topology operations.
         self._topology_lock = threading.Lock()
@@ -60,14 +59,6 @@ class TEManager:
             )
         else:
             self.graph = None
-
-        print(f"TEManager: connection_data: {connection_data}")
-
-        self.connection = self.connection_handler.import_connection_data(
-            connection_data
-        )
-
-        print(f"TEManager: self.connection: {self.connection}")
 
     def add_topology(self, topology_data: dict):
         """
@@ -169,12 +160,18 @@ class TEManager:
 
         return list(range(start, stop))
 
-    def generate_connection_te(self) -> TrafficMatrix:
+    def generate_connection_te(self, connection_request: dict) -> TrafficMatrix:
         """
         Generate a Traffic Matrix from the connection request we have.
         """
-        ingress_port = self.connection.ingress_port
-        egress_port = self.connection.egress_port
+        print(f"generate_connection_te: connection_request: {connection_request}")
+
+        request = ConnectionHandler().import_connection_data(connection_request)
+
+        print(f"generate_connection_te: decoded request: {request}")
+
+        ingress_port = request.ingress_port
+        egress_port = request.egress_port
 
         print(
             f"generate_connection_te(), ports: "
@@ -211,8 +208,8 @@ class TEManager:
             print(f"No egress node '{egress_node.id}' found in the graph")
             return None
 
-        required_bandwidth = self.connection.bandwidth or 0
-        required_latency = self.connection.latency or 0
+        required_bandwidth = request.bandwidth or 0
+        required_latency = request.latency or 0
 
         print(
             f"Setting required_latency: {required_latency}, "

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -339,7 +339,7 @@ class TEManager:
                 ingress_port = next_ingress_port
                 egress_port, next_ingress_port = self._get_ports_by_link(links[-1])
 
-            segment = {}                
+            segment = {}
             segment["ingress_port"] = ingress_port
             segment["egress_port"] = egress_port
             print(f"segment for {domain}: {segment}")

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -323,21 +323,14 @@ class TEManager:
 
             if first:
                 first = False
-
-                first_link = links[0]
-                i_port, _ = self._get_ports_by_link(first_link)
-
-                last_link = links[-1]
-                e_port, next_i = self._get_ports_by_link(last_link)
+                i_port, _ = self._get_ports_by_link(links[0])
+                e_port, next_i = self._get_ports_by_link(links[-1])
             elif i == len(breakdown) - 1:
                 i_port = next_i
-                last_link = links[-1]
-                _, e_port = self._get_ports_by_link(last_link)
+                _, e_port = self._get_ports_by_link(links[-1])
             else:
-                last_link = links[-1]
                 i_port = next_i
-                
-                e_port, next_i = self._get_ports_by_link(last_link)
+                e_port, next_i = self._get_ports_by_link(links[-1])
 
             segment = {}                
             segment["ingress_port"] = i_port

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -35,8 +35,6 @@ class TEManager:
     """
 
     def __init__(self, topology_data):
-        super().__init__()
-
         self.topology_manager = TopologyManager()
 
         # A lock to safely perform topology operations.

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -161,6 +161,12 @@ class TEManager:
     def generate_traffic_matrix(self, connection_request: dict) -> TrafficMatrix:
         """
         Generate a Traffic Matrix from the connection request we have.
+
+        A connection request specifies an ingress port, an egress
+        port, and some other properties.  The ports may belong to
+        different domains.  We need to break that request down into a
+        set of requests, each of them specific to a domain.  We call
+        such a domain-wise set of requests a traffic matrix.
         """
         print(f"generate_traffic_matrix: connection_request: {connection_request}")
 

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -261,19 +261,19 @@ class TEManager:
 
         return True
 
-    def generate_connection_breakdown(self, connection: ConnectionSolution) -> dict:
+    def generate_connection_breakdown(self, solution: ConnectionSolution) -> dict:
         """
         Take a connection solution and generate a breakdown.
 
         This is an alternative to generate_connection_breakdown()
         below which uses the newly defined types from sdx_pce.models.
         """
-        if connection is None or connection.connection_map is None:
-            print(f"Can't find a breakdown for {connection}")
+        if solution is None or solution.connection_map is None:
+            print(f"Can't find a breakdown for {solution}")
             return None
 
         breakdown = {}
-        paths = connection.connection_map  # p2p for now
+        paths = solution.connection_map  # p2p for now
 
         for domain, links in paths.items():
             print(f"domain: {domain}, links: {links}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -490,15 +490,14 @@ class TEManagerTests(unittest.TestCase):
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()
 
-        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
-        tm = self.temanager.generate_traffic_matrix(request)
-
         print(f"graph: {graph}")
-        print(f"tm: {tm}")
-
         self.assertIsNotNone(graph)
         self.assertIsInstance(graph, nx.Graph)
 
+        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
+        tm = self.temanager.generate_traffic_matrix(request)
+
+        print(f"tm: {tm}")
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -374,7 +374,7 @@ class TEManagerTests(unittest.TestCase):
 
         # Find solution for another identical connection request, and
         # compare solutions.  They should be different.
-        traffic_matrix2 = temanager.generate_connection_te()
+        traffic_matrix2 = temanager.generate_connection_te(connection_request)
 
         solution = TESolver(graph, traffic_matrix2).solve()
         print(f"TESolver result: {solution}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -469,7 +469,10 @@ class TEManagerTests(unittest.TestCase):
         # connection requests.
         self.assertEqual(len(breakdowns), num_requests)
 
-    def test_connection_amlight_to_zaoxi_two_requests(self):
+    def test_connection_amlight_to_zaoxi_two_distinct_requests(self):
+        """
+        Test with two distinct connection requests.
+        """
         temanager = TEManager(topology_data=None)
 
         for path in (
@@ -485,6 +488,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsInstance(graph, nx.Graph)
 
+        # Use a connection request that should span all three domains.
         connection_request1 = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"Connection request #1: {connection_request1}")
         traffic_matrix1 = temanager.generate_traffic_matrix(connection_request1)
@@ -501,6 +505,7 @@ class TEManagerTests(unittest.TestCase):
         breakdown1 = temanager.generate_connection_breakdown(solution1)
         print(f"Breakdown #1: {json.dumps(breakdown1)}")
 
+        # Use another connection request that spans just one domain.
         connection_request2 = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
         print(f"Connection request #2: {connection_request2}")
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -353,7 +353,7 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
 
-    def test_connection_amlight_to_zaoxi_two_requests(self):
+    def test_connection_amlight_to_zaoxi_two_identical_requests(self):
         """
         Exercise two identical connection requests.
         """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -26,7 +26,7 @@ class TEManagerTests(unittest.TestCase):
     def test_generate_solver_input(self):
         print("Test Convert Connection To Topology")
         request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
-        connection = self._make_connection(request)
+        connection = self._make_traffic_matrix_from_request(request)
         self.assertIsNotNone(connection)
 
     def test_connection_breakdown_none_input(self):
@@ -501,15 +501,15 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
 
-    def _make_connection(self, connection_request):
+    def _make_traffic_matrix_from_request(self, connection_request):
         graph = self.temanager.graph
         print(f"Generated networkx graph of the topology: {graph}")
         print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")
 
-        connection = self.temanager.generate_traffic_matrix(connection_request)
-        print(f"connection: {connection}")
+        traffic_matrix = self.temanager.generate_traffic_matrix(connection_request)
+        print(f"traffic_matrix: {traffic_matrix}")
 
-        return connection
+        return traffic_matrix
 
     def _make_tm_and_solve(self, request) -> ConnectionSolution:
         """
@@ -518,7 +518,7 @@ class TEManagerTests(unittest.TestCase):
         """
 
         # Make a connection request.
-        tm = self._make_traffic_matrix(request)
+        tm = self._make_traffic_matrix_from_list(request)
         print(f"tm: {tm}")
 
         graph = self.temanager.generate_graph_te()
@@ -534,7 +534,7 @@ class TEManagerTests(unittest.TestCase):
 
         return solution
 
-    def _make_traffic_matrix(self, old_style_request: list) -> TrafficMatrix:
+    def _make_traffic_matrix_from_list(self, old_style_request: list) -> TrafficMatrix:
         """
         Make a traffic matrix from the old-style list.
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -18,15 +18,15 @@ class TEManagerTests(unittest.TestCase):
 
     def setUp(self):
         topology = json.loads(TestData.TOPOLOGY_FILE_AMLIGHT.read_text())
-        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
-        self.temanager = TEManager(topology, request)
+        self.temanager = TEManager(topology)
 
     def tearDown(self):
         self.temanager = None
 
     def test_generate_solver_input(self):
         print("Test Convert Connection To Topology")
-        connection = self._make_connection()
+        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
+        connection = self._make_connection(request)
         self.assertIsNotNone(connection)
 
     def test_connection_breakdown_none_input(self):
@@ -200,7 +200,7 @@ class TEManagerTests(unittest.TestCase):
         topology = json.loads(TestData.TOPOLOGY_FILE_SAX_2.read_text())
         request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_INVALID.read_text())
 
-        temanager = TEManager(topology, request)
+        temanager = TEManager(topology)
         self.assertIsNotNone(temanager)
 
         graph = temanager.generate_graph_te()
@@ -210,7 +210,7 @@ class TEManagerTests(unittest.TestCase):
         # Expect None because the connection_data contains
         # unresolvable port IDs, which are not present in the given
         # topology.
-        connection = temanager.generate_connection_te()
+        connection = temanager.generate_connection_te(request)
         self.assertIsNone(connection)
 
     def test_generate_graph_and_connection_with_sax_2_valid(self):
@@ -223,7 +223,7 @@ class TEManagerTests(unittest.TestCase):
         topology = json.loads(TestData.TOPOLOGY_FILE_SAX_2.read_text())
         request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_VALID.read_text())
 
-        temanager = TEManager(topology, request)
+        temanager = TEManager(topology)
         self.assertIsNotNone(temanager)
 
         graph = temanager.generate_graph_te()
@@ -232,7 +232,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(graph)
         self.assertIsInstance(graph, nx.Graph)
 
-        tm = temanager.generate_connection_te()
+        tm = temanager.generate_connection_te(request)
         print(f"traffic matrix: {tm}")
         self.assertIsInstance(tm, TrafficMatrix)
 
@@ -260,7 +260,7 @@ class TEManagerTests(unittest.TestCase):
         connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")
 
-        temanager = TEManager(topology_data=None, connection_data=connection_request)
+        temanager = TEManager(topology_data=None)
 
         for path in (
             TestData.TOPOLOGY_FILE_AMLIGHT,
@@ -271,7 +271,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te()
+        traffic_matrix = temanager.generate_connection_te(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -339,7 +339,7 @@ class TEManagerTests(unittest.TestCase):
         connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")
 
-        temanager = TEManager(topology_data=None, connection_data=connection_request)
+        temanager = TEManager(topology_data=None)
 
         for path in (
             TestData.TOPOLOGY_FILE_AMLIGHT,
@@ -350,7 +350,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te()
+        traffic_matrix = temanager.generate_connection_te(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -405,7 +405,7 @@ class TEManagerTests(unittest.TestCase):
         connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
         print(f"connection_request: {connection_request}")
 
-        temanager = TEManager(topology_data=None, connection_data=connection_request)
+        temanager = TEManager(topology_data=None)
 
         for path in (
             TestData.TOPOLOGY_FILE_AMLIGHT,
@@ -416,7 +416,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te()
+        traffic_matrix = temanager.generate_connection_te(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -463,12 +463,10 @@ class TEManagerTests(unittest.TestCase):
         topology_data = json.loads(TestData.TOPOLOGY_FILE_SDX.read_text())
         print(f"topology_data: {topology_data}")
 
-        temanager = TEManager(
-            topology_data=topology_data, connection_data=connection_request
-        )
+        temanager = TEManager(topology_data=topology_data)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te()
+        traffic_matrix = temanager.generate_connection_te(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -493,7 +491,9 @@ class TEManagerTests(unittest.TestCase):
 
     def test_generate_graph_and_connection(self):
         graph = self.temanager.generate_graph_te()
-        tm = self.temanager.generate_connection_te()
+
+        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
+        tm = self.temanager.generate_connection_te(request)
 
         print(f"graph: {graph}")
         print(f"tm: {tm}")
@@ -504,12 +504,12 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
 
-    def _make_connection(self):
+    def _make_connection(self, connection_request):
         graph = self.temanager.graph
         print(f"Generated networkx graph of the topology: {graph}")
         print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")
 
-        connection = self.temanager.generate_connection_te()
+        connection = self.temanager.generate_connection_te(connection_request)
         print(f"connection: {connection}")
 
         return connection

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -252,6 +252,28 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNone(solution.connection_map, None)
         self.assertEqual(solution.cost, 0.0)
 
+    def test_connection_amlight(self):
+        """
+        Test with just one topology/domain.
+        """
+        temanager = TEManager(topology_data=None)
+
+        topology = json.loads(TestData.TOPOLOGY_FILE_AMLIGHT.read_text())
+        temanager.add_topology(topology)
+        graph = temanager.generate_graph_te()
+
+        self.assertIsInstance(graph, nx.Graph)
+
+        request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
+        print(f"connection request: {request}")
+
+        traffic_matrix = temanager.generate_traffic_matrix(request)
+        self.assertIsInstance(traffic_matrix, TrafficMatrix)
+
+        solution = TESolver(graph, traffic_matrix).solve()
+        print(f"TESolver result: {solution}")
+        self.assertIsInstance(solution, ConnectionSolution)
+
     def test_connection_amlight_to_zaoxi(self):
         """
         Exercise a connection request between Amlight and Zaoxi.

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -198,9 +198,8 @@ class TEManagerTests(unittest.TestCase):
         TODO: Use a better name for this method.
         """
         topology = json.loads(TestData.TOPOLOGY_FILE_SAX_2.read_text())
-        request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_INVALID.read_text())
-
         temanager = TEManager(topology)
+
         self.assertIsNotNone(temanager)
 
         graph = temanager.generate_graph_te()
@@ -210,6 +209,7 @@ class TEManagerTests(unittest.TestCase):
         # Expect None because the connection_data contains
         # unresolvable port IDs, which are not present in the given
         # topology.
+        request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_INVALID.read_text())
         tm = temanager.generate_traffic_matrix(request)
         self.assertIsNone(tm)
 
@@ -221,17 +221,16 @@ class TEManagerTests(unittest.TestCase):
         TODO: Use a better name for this method.
         """
         topology = json.loads(TestData.TOPOLOGY_FILE_SAX_2.read_text())
-        request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_VALID.read_text())
-
         temanager = TEManager(topology)
+
         self.assertIsNotNone(temanager)
 
         graph = temanager.generate_graph_te()
-
         print(f"graph: {graph}")
         self.assertIsNotNone(graph)
         self.assertIsInstance(graph, nx.Graph)
 
+        request = json.loads(TestData.CONNECTION_REQ_FILE_SAX_2_VALID.read_text())
         tm = temanager.generate_traffic_matrix(request)
         print(f"traffic matrix: {tm}")
         self.assertIsInstance(tm, TrafficMatrix)
@@ -257,9 +256,6 @@ class TEManagerTests(unittest.TestCase):
         """
         Exercise a connection request between Amlight and Zaoxi.
         """
-        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
-        print(f"connection_request: {connection_request}")
-
         temanager = TEManager(topology_data=None)
 
         for path in (
@@ -271,6 +267,9 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
+
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
+        print(f"connection_request: {connection_request}")
         traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
@@ -336,9 +335,6 @@ class TEManagerTests(unittest.TestCase):
         """
         Exercise two identical connection requests.
         """
-        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
-        print(f"connection_request: {connection_request}")
-
         temanager = TEManager(topology_data=None)
 
         for path in (
@@ -350,6 +346,9 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
+
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
+        print(f"connection_request: {connection_request}")
         traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
@@ -402,9 +401,6 @@ class TEManagerTests(unittest.TestCase):
         """
         Exercise many identical connection requests.
         """
-        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
-        print(f"connection_request: {connection_request}")
-
         temanager = TEManager(topology_data=None)
 
         for path in (
@@ -416,6 +412,9 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
+
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
+        print(f"connection_request: {connection_request}")
         traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
@@ -456,16 +455,15 @@ class TEManagerTests(unittest.TestCase):
         have a merged topology, nodes do not resolve to correct
         domains.
         """
-
-        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
-        print(f"connection_request: {connection_request}")
-
         topology_data = json.loads(TestData.TOPOLOGY_FILE_SDX.read_text())
         print(f"topology_data: {topology_data}")
 
         temanager = TEManager(topology_data=topology_data)
 
         graph = temanager.generate_graph_te()
+
+        connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
+        print(f"connection_request: {connection_request}")
         traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -210,7 +210,7 @@ class TEManagerTests(unittest.TestCase):
         # Expect None because the connection_data contains
         # unresolvable port IDs, which are not present in the given
         # topology.
-        connection = temanager.generate_connection_te(request)
+        connection = temanager.generate_traffic_matrix(request)
         self.assertIsNone(connection)
 
     def test_generate_graph_and_connection_with_sax_2_valid(self):
@@ -232,7 +232,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(graph)
         self.assertIsInstance(graph, nx.Graph)
 
-        tm = temanager.generate_connection_te(request)
+        tm = temanager.generate_traffic_matrix(request)
         print(f"traffic matrix: {tm}")
         self.assertIsInstance(tm, TrafficMatrix)
 
@@ -271,7 +271,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te(connection_request)
+        traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -350,7 +350,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te(connection_request)
+        traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -374,7 +374,7 @@ class TEManagerTests(unittest.TestCase):
 
         # Find solution for another identical connection request, and
         # compare solutions.  They should be different.
-        traffic_matrix2 = temanager.generate_connection_te(connection_request)
+        traffic_matrix2 = temanager.generate_traffic_matrix(connection_request)
 
         solution = TESolver(graph, traffic_matrix2).solve()
         print(f"TESolver result: {solution}")
@@ -416,7 +416,7 @@ class TEManagerTests(unittest.TestCase):
             temanager.add_topology(topology)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te(connection_request)
+        traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -466,7 +466,7 @@ class TEManagerTests(unittest.TestCase):
         temanager = TEManager(topology_data=topology_data)
 
         graph = temanager.generate_graph_te()
-        traffic_matrix = temanager.generate_connection_te(connection_request)
+        traffic_matrix = temanager.generate_traffic_matrix(connection_request)
 
         print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
 
@@ -493,7 +493,7 @@ class TEManagerTests(unittest.TestCase):
         graph = self.temanager.generate_graph_te()
 
         request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
-        tm = self.temanager.generate_connection_te(request)
+        tm = self.temanager.generate_traffic_matrix(request)
 
         print(f"graph: {graph}")
         print(f"tm: {tm}")
@@ -509,7 +509,7 @@ class TEManagerTests(unittest.TestCase):
         print(f"Generated networkx graph of the topology: {graph}")
         print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")
 
-        connection = self.temanager.generate_connection_te(connection_request)
+        connection = self.temanager.generate_traffic_matrix(connection_request)
         print(f"connection: {connection}")
 
         return connection

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -501,7 +501,12 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(tm)
         self.assertIsInstance(tm, TrafficMatrix)
 
-    def _make_traffic_matrix_from_request(self, connection_request):
+    def _make_traffic_matrix_from_request(
+        self, connection_request: dict
+    ) -> TrafficMatrix:
+        """
+        Make a traffic matrix out of a connection request dict.
+        """
         graph = self.temanager.graph
         print(f"Generated networkx graph of the topology: {graph}")
         print(f"Graph nodes: {graph.nodes[0]}, edges: {graph.edges}")

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -210,8 +210,8 @@ class TEManagerTests(unittest.TestCase):
         # Expect None because the connection_data contains
         # unresolvable port IDs, which are not present in the given
         # topology.
-        connection = temanager.generate_traffic_matrix(request)
-        self.assertIsNone(connection)
+        tm = temanager.generate_traffic_matrix(request)
+        self.assertIsNone(tm)
 
     def test_generate_graph_and_connection_with_sax_2_valid(self):
         """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -469,6 +469,58 @@ class TEManagerTests(unittest.TestCase):
         # connection requests.
         self.assertEqual(len(breakdowns), num_requests)
 
+    def test_connection_amlight_to_zaoxi_two_requests(self):
+        temanager = TEManager(topology_data=None)
+
+        for path in (
+            TestData.TOPOLOGY_FILE_AMLIGHT,
+            TestData.TOPOLOGY_FILE_SAX,
+            TestData.TOPOLOGY_FILE_ZAOXI,
+        ):
+            topology = json.loads(path.read_text())
+            temanager.add_topology(topology)
+
+        graph = temanager.generate_graph_te()
+        print(f"Generated graph: '{graph}'")
+
+        self.assertIsInstance(graph, nx.Graph)
+
+        connection_request1 = json.loads(TestData.CONNECTION_REQ.read_text())
+        print(f"Connection request #1: {connection_request1}")
+        traffic_matrix1 = temanager.generate_traffic_matrix(connection_request1)
+
+        print(f"Traffic matrix #1: '{traffic_matrix1}'")
+        self.assertIsInstance(traffic_matrix1, TrafficMatrix)
+
+        solution1 = TESolver(graph, traffic_matrix1).solve()
+        print(f"TESolver result #1: {solution1}")
+
+        self.assertIsInstance(solution1, ConnectionSolution)
+        self.assertIsNotNone(solution1.connection_map)
+
+        breakdown1 = temanager.generate_connection_breakdown(solution1)
+        print(f"Breakdown #1: {json.dumps(breakdown1)}")
+
+        connection_request2 = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())
+        print(f"Connection request #2: {connection_request2}")
+
+        traffic_matrix2 = temanager.generate_traffic_matrix(connection_request2)
+        print(f"Traffic matrix #2: '{traffic_matrix2}'")
+        self.assertIsInstance(traffic_matrix2, TrafficMatrix)
+
+        solution2 = TESolver(graph, traffic_matrix2).solve()
+        print(f"TESolver result #2: {solution2}")
+
+        self.assertIsInstance(solution2, ConnectionSolution)
+        self.assertIsNotNone(solution2.connection_map)
+
+        breakdown2 = temanager.generate_connection_breakdown(solution1)
+        print(f"Breakdown #2: {json.dumps(breakdown2)}")
+
+        self.assertNotEqual(connection_request1, connection_request2)
+        self.assertNotEqual(solution1, solution2)
+        self.assertNotEqual(breakdown1, breakdown2)
+
     def test_connection_amlight_to_zaoxi_with_merged_topology(self):
         """
         Solve with the "merged" topology of amlight, sax, and zaoxi.

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -523,6 +523,7 @@ class TEManagerTests(unittest.TestCase):
         print(f"Breakdown #2: {json.dumps(breakdown2)}")
 
         self.assertNotEqual(connection_request1, connection_request2)
+        self.assertNotEqual(traffic_matrix1, traffic_matrix2)
         self.assertNotEqual(solution1, solution2)
         self.assertNotEqual(breakdown1, breakdown2)
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -398,7 +398,7 @@ class TEManagerTests(unittest.TestCase):
         print(f"sax: {sax}, sax2: {sax2}")
         print(f"amlight: {amlight}, amlight2: {amlight2}")
 
-    def test_connection_amlight_to_zaoxi_many_requests(self):
+    def test_connection_amlight_to_zaoxi_many_identical_requests(self):
         """
         Exercise many identical connection requests.
         """

--- a/tests/test_te_solver.py
+++ b/tests/test_te_solver.py
@@ -111,8 +111,7 @@ class TESolverTests(unittest.TestCase):
             ),
         )
 
-        with open(traffic_matrix_file) as fp:
-            tm = TrafficMatrix.from_dict(json.load(fp))
+        tm = TrafficMatrix.from_dict(json.loads(traffic_matrix_file.read_text()))
 
         solution = TESolver(graph, tm, Constants.COST_FLAG_HOP).solve()
         print(f"Solution: {solution}")
@@ -138,8 +137,7 @@ class TESolverTests(unittest.TestCase):
         self.assertNotEqual(graph, None, "Could not read dot file")
 
         connection_file = TestData.TEST_DATA_DIR / "test_connection.json"
-        with open(connection_file) as fp:
-            tm = TrafficMatrix.from_dict(json.load(fp))
+        tm = TrafficMatrix.from_dict(json.loads(connection_file.read_text()))
 
         self.assertNotEqual(tm, None, "Could not read connection file")
 

--- a/tests/test_te_solver_static.py
+++ b/tests/test_te_solver_static.py
@@ -29,16 +29,16 @@ class TESolverTests(unittest.TestCase):
     ]
 
     def setUp(self):
-        with open(TestData.TOPOLOGY_FILE_SDX, "r", encoding="utf-8") as t:
-            topology_data = json.load(t)
-        with open(TestData.CONNECTION_REQ, "r", encoding="utf-8") as c:
-            connection_data = json.load(c)
+        topology_data = json.loads(TestData.TOPOLOGY_FILE_SDX.read_text())
+        self.temanager = TEManager(topology_data)
 
-        self.temanager = TEManager(topology_data, connection_data)
+        self.connection_request = json.loads(TestData.CONNECTION_REQ.read_text())
 
     def test_computation_breakdown(self):
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_connection_te()
+        connection_request = self.temanager.generate_connection_te(
+            self.connection_request
+        )
 
         print(f"Number of nodes: {graph.number_of_nodes()}")
         print(f"Graph edges: {graph.edges}")
@@ -64,7 +64,9 @@ class TESolverTests(unittest.TestCase):
         graph = self.temanager.generate_graph_te()
         print(f"Graph: {graph}")
 
-        connection_request = self.temanager.generate_connection_te()
+        connection_request = self.temanager.generate_connection_te(
+            self.connection_request
+        )
         print(f"Connection Request: {connection_request}")
 
         conn = self.temanager.requests_connectivity(connection_request)
@@ -94,7 +96,9 @@ class TESolverTests(unittest.TestCase):
                 self.temanager.update_topology(data)
 
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_connection_te()
+        connection_request = self.temanager.generate_connection_te(
+            self.connection_request
+        )
 
         conn = self.temanager.requests_connectivity(connection_request)
         print(f"Graph connectivity: {conn}")

--- a/tests/test_te_solver_static.py
+++ b/tests/test_te_solver_static.py
@@ -36,7 +36,7 @@ class TESolverTests(unittest.TestCase):
 
     def test_computation_breakdown(self):
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_connection_te(
+        connection_request = self.temanager.generate_traffic_matrix(
             self.connection_request
         )
 
@@ -64,7 +64,7 @@ class TESolverTests(unittest.TestCase):
         graph = self.temanager.generate_graph_te()
         print(f"Graph: {graph}")
 
-        connection_request = self.temanager.generate_connection_te(
+        connection_request = self.temanager.generate_traffic_matrix(
             self.connection_request
         )
         print(f"Connection Request: {connection_request}")
@@ -96,7 +96,7 @@ class TESolverTests(unittest.TestCase):
                 self.temanager.update_topology(data)
 
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_connection_te(
+        connection_request = self.temanager.generate_traffic_matrix(
             self.connection_request
         )
 

--- a/tests/test_te_solver_static.py
+++ b/tests/test_te_solver_static.py
@@ -36,15 +36,13 @@ class TESolverTests(unittest.TestCase):
 
     def test_computation_breakdown(self):
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_traffic_matrix(
-            self.connection_request
-        )
+        tm = self.temanager.generate_traffic_matrix(self.connection_request)
 
         print(f"Number of nodes: {graph.number_of_nodes()}")
         print(f"Graph edges: {graph.edges}")
-        print(f"Traffic Matrix: {connection_request}")
+        print(f"Traffic Matrix: {tm}")
 
-        solution = TESolver(graph, connection_request).solve()
+        solution = TESolver(graph, tm).solve()
         print(f"TESolver result: {solution}")
 
         self.assertIsInstance(solution, ConnectionSolution)
@@ -63,15 +61,13 @@ class TESolverTests(unittest.TestCase):
         graph = self.temanager.generate_graph_te()
         print(f"Graph: {graph}")
 
-        connection_request = self.temanager.generate_traffic_matrix(
-            self.connection_request
-        )
-        print(f"Connection Request: {connection_request}")
+        tm = self.temanager.generate_traffic_matrix(self.connection_request)
+        print(f"Traffic matrix: {tm}")
 
-        conn = self.temanager.requests_connectivity(connection_request)
+        conn = self.temanager.requests_connectivity(tm)
         print(f"Graph connectivity: {conn}")
 
-        solution = TESolver(graph, connection_request).solve()
+        solution = TESolver(graph, tm).solve()
         print(f"TESolver result: {solution}")
 
         self.assertIsNotNone(solution.connection_map)
@@ -93,14 +89,12 @@ class TESolverTests(unittest.TestCase):
             self.temanager.update_topology(data)
 
         graph = self.temanager.generate_graph_te()
-        connection_request = self.temanager.generate_traffic_matrix(
-            self.connection_request
-        )
+        tm = self.temanager.generate_traffic_matrix(self.connection_request)
 
-        conn = self.temanager.requests_connectivity(connection_request)
+        conn = self.temanager.requests_connectivity(tm)
         print(f"Graph connectivity: {conn}")
 
-        solution = TESolver(graph, connection_request).solve()
+        solution = TESolver(graph, tm).solve()
         print(f"TESolver result: {solution}")
 
         self.assertIsNotNone(solution.connection_map)

--- a/tests/test_te_solver_static.py
+++ b/tests/test_te_solver_static.py
@@ -57,9 +57,8 @@ class TESolverTests(unittest.TestCase):
     def test_computation_breakdown_many_topologies(self):
         for topology_file in self.TOPOLOGY_FILE_LIST:
             print(f"Adding Topology: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as data_file:
-                data = json.load(data_file)
-                self.temanager.topology_manager.add_topology(data)
+            data = json.loads(topology_file.read_text())
+            self.temanager.topology_manager.add_topology(data)
 
         graph = self.temanager.generate_graph_te()
         print(f"Graph: {graph}")
@@ -85,15 +84,13 @@ class TESolverTests(unittest.TestCase):
     def test_computation_update(self):
         for topology_file in self.TOPOLOGY_FILE_LIST:
             print(f"Adding Topology: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as data_file:
-                data = json.load(data_file)
-                self.temanager.add_topology(data)
+            data = json.loads(topology_file.read_text())
+            self.temanager.add_topology(data)
 
         for topology_file in self.TOPOLOGY_FILE_LIST_UPDATE:
             print(f"Updating Topology: {topology_file}")
-            with open(topology_file, "r", encoding="utf-8") as data_file:
-                data = json.load(data_file)
-                self.temanager.update_topology(data)
+            data = json.loads(topology_file.read_text())
+            self.temanager.update_topology(data)
 
         graph = self.temanager.generate_graph_te()
         connection_request = self.temanager.generate_traffic_matrix(


### PR DESCRIPTION
Fixes #158.  Changes:

- Overhaul `TEManager` class such that `TEManager(topology_data, connection_request)` is changed to `TEManager(topology_data)`.
- Change `generate_connection_te()` to `generate_connection_matrix(traffic_request)` - now this method takes a connection request, not `TEManager` constructor.
- Update and add some tests accordingly.
- Add a test that uses two distinct connection requests.