### PR TITLE
#175: assign float(inf) to be the default request latency

### DIFF
--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -234,7 +234,7 @@ class TEManager:
             return None
 
         required_bandwidth = request.bandwidth or 0
-        required_latency = request.latency or 0
+        required_latency = request.latency or float('inf')
         request_id = request.id
 
         self._logger.info(

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -24,7 +24,6 @@ UNUSED_VLAN = None
 
 
 class TEManager:
-
     """
     TE Manager for connection - topology operations.
 
@@ -234,7 +233,7 @@ class TEManager:
             return None
 
         required_bandwidth = request.bandwidth or 0
-        required_latency = request.latency or float('inf')
+        required_latency = request.latency or float("inf")
         request_id = request.id
 
         self._logger.info(

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -247,16 +247,16 @@ class TEManagerTests(unittest.TestCase):
             self.assertEqual(request.source, 1)
             self.assertEqual(request.destination, 0)
             self.assertEqual(request.required_bandwidth, 0)
-            self.assertEqual(request.required_latency, 0)
+            self.assertEqual(request.required_latency, float("inf"))
 
         solver = TESolver(graph, tm)
         self.assertIsNotNone(solver)
 
-        # Solver will fail to find a solution here.
+        # Solver will find a solution here.
         solution = solver.solve()
         print(f"Solution to tm {tm}: {solution}")
-        self.assertIsNone(solution.connection_map, None)
-        self.assertEqual(solution.cost, 0.0)
+        self.assertIsNotNone(solution.connection_map, None)
+        self.assertEqual(solution.cost, 1.0)
 
     def test_connection_amlight(self):
         """


### PR DESCRIPTION
As described by Italo in issue #175.
The unites sets the default to be a higher number, so this is why it's not covered.

in test_te_manager._make_traffic_matrix_from_list: line 170
                if len(request) >= 4:
                    required_latency = request[3]
                else:
                    # Use a very high latency default latency value in tests.
                    required_latency = 100 