### PR TITLE
expand allowed vlan_range format

### DIFF
--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -209,7 +209,7 @@ class TEManager:
 
                 self._vlan_tags_table[domain_name][port_id] = labels_available
 
-    def _expand_label_range(self, label_range: List[str]) -> List[int]:
+    def _expand_label_range(self, label_range: []) -> List[int]:
         """
         Expand the label range to a list of numbers.
         """
@@ -217,7 +217,9 @@ class TEManager:
         # flatten result and return it.
         return list(chain.from_iterable(labels))
 
-    def _expand_label(self, label: str) -> List[int]:
+    def _expand_label(self, label) -> List[int]:
+
+        start = stop = 0
         """
         Expand items in label range to a list of numbers.
 
@@ -225,12 +227,33 @@ class TEManager:
         For the first case, we return [100,101,...200]; for the second
         case, we return [100].
         """
-        if not isinstance(label, str):
-            raise ValidationError("Label must be a string.")
+        if isinstance(label, str):
+            parts = label.split("-")
+            start = int(parts[0])
+            stop = int(parts[-1]) + 1
 
-        parts = label.split("-")
-        start = int(parts[0])
-        stop = int(parts[-1]) + 1
+        if isinstance(label, int):
+            start = label
+            stop = label + 1
+        """
+        Items in label ranges can be of the form [100, 200].
+        For the first case, we return [100,101,...200].
+        """
+        if isinstance(label, list):
+            start = label[0]
+            stop = label[1] + 1
+
+        """
+        Items in label ranges can be of the form (100, 200).
+        For the first case, we return [100,101,...200].
+        """
+
+        if isinstance(label, tuple):
+            start = label[0]
+            stop = label[1] + 1
+
+        if start == 0 or stop == 0 or start > stop:
+            raise ValidationError(f"Invalid label range: {label}")
 
         return list(range(start, stop))
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -23,6 +23,44 @@ class TEManagerTests(unittest.TestCase):
     def tearDown(self):
         self.temanager = None
 
+    def test_expand_label_range(self):
+        """
+        Test the _expand_label_range() method.
+        """
+        # Test case 1: Single label range
+        label_range = [[100, 105], 110]
+        expanded_range = self.temanager._expand_label_range(label_range)
+        expected_range = [100, 101, 102, 103, 104, 105, 110]
+        self.assertEqual(expanded_range, expected_range)
+
+        # Test case 2: Multiple label ranges
+        label_ranges = [[200, 205], (300, 305), "310-312"]
+        expanded_ranges = self.temanager._expand_label_range(label_ranges)
+        expected_ranges = [
+            200,
+            201,
+            202,
+            203,
+            204,
+            205,
+            300,
+            301,
+            302,
+            303,
+            304,
+            305,
+            310,
+            311,
+            312,
+        ]
+        self.assertEqual(expanded_ranges, expected_ranges)
+
+        # Test case 3: Empty label range
+        label_range = []
+        expanded_range = self.temanager._expand_label_range(label_range)
+        expected_range = []
+        self.assertEqual(expanded_range, expected_range)
+
     def test_generate_solver_input(self):
         print("Test Convert Connection To Topology")
         request = json.loads(TestData.CONNECTION_REQ_AMLIGHT.read_text())


### PR DESCRIPTION
1.  "min-max"
2. min
3. list [min, max] 
4. tuple (min, max)

@sajith, I did a quick  fix to allow all above format for vlan_range, esp, the tuple (), along with an unittest.

Well, port_handler._validate_vlan_range() would need to add the tuple too, and the unit tests cases.....

See if we all agree on this.



 