### PR TITLE
Fix error on vlan reservation and add backward compatibility to Port.label_range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@main",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@fix/issue_pce_200",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@fix/issue_pce_200",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@main",
 ]
 
 [project.urls]

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -145,7 +145,7 @@ class TEManager:
                 # port itself (v1), or from the services attached to it (v2).
                 label_range = self.get_port_obj_services_label_range(port)
                 if label_range is None:
-                    label_range = port.label_range
+                    label_range = port.vlan_range
 
                 # TODO: why is label_range sometimes None, and what to
                 # do when that happens?

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -884,7 +884,7 @@ class TEManager:
                 if vlan_usage is UNUSED_VLAN:
                     available_tag = vlan_tag
         else:
-            if vlan_table[tag] is UNUSED_VLAN:
+            if tag in vlan_table and vlan_table[tag] is UNUSED_VLAN:
                 available_tag = tag
             else:
                 return None


### PR DESCRIPTION
Fix #200 

Heads-UP: this PR depends on https://github.com/atlanticwave-sdx/datamodel/pull/141

### Description of the change

- VLAN reservation routine had a bug where if the user requests a VLAN which is not on the VLAN table (meaning: the OXP does not specify that VLAN on their allowed range -- which by the way should be discussed), the `TEManager._reserve_vlan` call would fail with KeyError when running unit test:
```
FAILED tests/test_te_manager.py::TEManagerTests::test_connection_amlight_to_zaoxi_user_port_v2 - KeyError: 777
```

- Added backward compatibility to Port.label_range (also handled on datamodel PortHandler)