### PR TITLE
Add extra check to TE Graph to remove disabled or down Links before computing the solution

### DIFF
--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -377,6 +377,8 @@ class TopologyManager:
         links = self._topology.links
         for link in links:
             inter_domain_link = False
+            if link.status not in ("up", None) or link.state not in ("enabled", None):
+                continue
             ports = link.ports
             end_nodes = []
             for port in ports:


### PR DESCRIPTION
Fix #203 

Heads-UP: this PR sits on top of #209 

### Description of the change 

- This PR adds a simple fix to the topology TE graph to omit unhealthy Links (i.e., Links that are not UP/Enabled)
- Adding unit tests to cover requests and topology changes for disabling links
