### PR TITLE
Add means to calculate failed links on the topology

### DIFF
--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -366,6 +366,15 @@ class TopologyManager:
                 continue
             self.create_update_interdomain_link(port, other_port)
 
+    def get_failed_links(self) -> dict:
+        """Get failed links on the topology (ie., Links not up and enabled)."""
+        failed_links = []
+        for link in self._topology.links:
+            if link.status in ("up", None) and link.state in ("enabled", None):
+                continue
+            failed_links.append({"id": link.id, "ports": link.ports})
+        return failed_links
+
     # adjacent matrix of the graph, in jason?
     def generate_graph(self):
         graph = nx.Graph()

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -117,6 +117,10 @@ class TEManager:
             vlan_range = services.l2vpn_ptp.get("vlan_range")
         return vlan_range
 
+    def get_failed_links(self) -> List[dict]:
+        """Get failed links on the topology (ie., Links not up and enabled)."""
+        return self.topology_manager.get_failed_links()
+
     def _update_vlan_tags_table(self, domain_name: str, port_map: dict):
         """
         Update VLAN tags table.

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1074,3 +1074,27 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("value"), int)
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
+
+    def test_get_failed_links(self):
+        """Test get_failed_links()."""
+
+        topology = json.loads(TestData.TOPOLOGY_FILE_AMLIGHT_v2.read_text())
+        temanager = TEManager(topology)
+        graph = temanager.generate_graph_te()
+
+        topology["links"][2]["status"] = "down"
+        temanager.update_topology(topology)
+
+        expected_failed_links = [
+            {
+                "id": "urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1",
+                "ports": [
+                    "urn:sdx:port:ampath.net:Ampath1:1",
+                    "urn:sdx:port:ampath.net:Ampath2:1",
+                ],
+            }
+        ]
+
+        failed_links = temanager.get_failed_links()
+
+        self.assertEqual(failed_links, expected_failed_links)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1080,7 +1080,6 @@ class TEManagerTests(unittest.TestCase):
 
         topology = json.loads(TestData.TOPOLOGY_FILE_AMLIGHT_v2.read_text())
         temanager = TEManager(topology)
-        graph = temanager.generate_graph_te()
 
         topology["links"][2]["status"] = "down"
         temanager.update_topology(topology)


### PR DESCRIPTION
Related to https://github.com/atlanticwave-sdx/sdx-controller/issues/161

Heads-Up: sits on top of the other in-flight pull requests (#207 and #209 and #210) 

### Description of the change

Basically adds a function which returns the failed links to be used after the topology update and help identify connections to be redeployed (https://github.com/atlanticwave-sdx/sdx-controller/issues/161)