### PR TITLE
Fix/issue 212

### DIFF
--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -253,6 +253,11 @@ class TopologyManager:
         # inter-domain links
         self.add_inter_domain_links(topology, interdomain_ports)
 
+        # Update the port node map
+        for node in topology.nodes:
+            for port in node.ports:
+                self._port_node_map[port.id] = node
+
         self.update_version(True)
         self.update_timestamp()
 


### PR DESCRIPTION
Fix #212

### Description of the change

As described on issue #212, the `_port_node_map` is used to create interdomain links and to compute VLAN Table. It happened that `_port_node_map` was being updated only when topology_add() was called. This pull request adds the update of the `_port_node_map` to be executed also when the topology is updated. That way, new nodes, new ports, changed IDs, etc. all get reflected on the port node map.