### PR TITLE
227 creating a connection to a port directly attached to a neighbor domain results in wrong breakdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@3.0.0.dev0",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@3.0.0.dev1",
 ]
 
 [project.urls]

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -426,6 +426,10 @@ class TEManager:
                         breakdown[current_domain] = current_link_set.copy()
                 else:
                     breakdown[current_domain] = current_link_set.copy()
+                    if count == len(links) - 1:
+                        current_link_set = []
+                        current_link_set.append(link)
+                        breakdown[dst_domain] = current_link_set.copy()
                     current_domain = None
                     current_link_set = []
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,9 @@ class TestData:
     CONNECTION_REQ_AMLIGHT_ZAOXI_USER_PORT_v2 = (
         REQUESTS_DIR / "test_request-amlight_zaoxi-p2p-v2.json"
     )
+    CONNECTION_REQ_AMLIGHT_SAX_v2 = (
+        REQUESTS_DIR / "test-request-amlight_sax-p2p-v2.json"
+    )
 
     # Write test output files in OS temporary directory.
     TEST_OUTPUT_DIR = pathlib.Path(tempfile.gettempdir())

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -586,9 +586,9 @@ class TEManagerTests(unittest.TestCase):
         temanager = TEManager(topology_data=None)
 
         for path in (
-            TestData.TOPOLOGY_FILE_AMLIGHT_USER_PORT,
-            TestData.TOPOLOGY_FILE_SAX,
-            TestData.TOPOLOGY_FILE_ZAOXI,
+            TestData.TOPOLOGY_FILE_AMLIGHT_v2,
+            TestData.TOPOLOGY_FILE_SAX_v2,
+            TestData.TOPOLOGY_FILE_ZAOXI_v2,
         ):
             topology = json.loads(path.read_text())
             temanager.add_topology(topology)
@@ -631,10 +631,13 @@ class TEManagerTests(unittest.TestCase):
         # result when we initialize TEManager with None for topology,
         # and later add individual topologies with add_topology().
         zaoxi = breakdown.get("urn:sdx:topology:zaoxi.net")
+        print(f"Breakdown, ZAOXI: {zaoxi}")
         sax = breakdown.get("urn:sdx:topology:sax.net")
-        amlight = breakdown.get("urn:sdx:topology:amlight.net")
+        print(f"Breakdown, SAX: {sax}")
+        amlight = breakdown.get("urn:sdx:topology:ampath.net")
+        print(f"Breakdown, AMLIGHT: {amlight}")
 
-        for segment in [zaoxi, sax, amlight]:
+        for segment in [sax, amlight]:
             self.assertIsInstance(segment, dict)
             self.assertIsInstance(segment.get("name"), str)
             self.assertIsInstance(segment.get("dynamic_backup_path"), bool)
@@ -648,7 +651,6 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("value"), int)
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
-
 
     def test_connection_amlight_to_zaoxi_two_identical_requests(self):
         """

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -579,6 +579,77 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
 
+    def test_connection_amlight_to_sax_v2(self):
+        """
+        Exercise a connection request between Amlight and Zaoxi.
+        """
+        temanager = TEManager(topology_data=None)
+
+        for path in (
+            TestData.TOPOLOGY_FILE_AMLIGHT_USER_PORT,
+            TestData.TOPOLOGY_FILE_SAX,
+            TestData.TOPOLOGY_FILE_ZAOXI,
+        ):
+            topology = json.loads(path.read_text())
+            temanager.add_topology(topology)
+
+        graph = temanager.generate_graph_te()
+
+        connection_request = json.loads(
+            TestData.CONNECTION_REQ_AMLIGHT_SAX_v2.read_text()
+        )
+        print(f"connection_request: {connection_request}")
+        traffic_matrix = temanager.generate_traffic_matrix(connection_request)
+
+        print(f"Generated graph: '{graph}', traffic matrix: '{traffic_matrix}'")
+
+        self.assertIsNotNone(graph)
+        self.assertIsNotNone(traffic_matrix)
+
+        conn = temanager.requests_connectivity(traffic_matrix)
+        print(f"Graph connectivity: {conn}")
+
+        solution = TESolver(graph, traffic_matrix).solve()
+        print(f"TESolver result: {solution}")
+
+        self.assertIsNotNone(solution.connection_map)
+
+        links = temanager.get_links_on_path(solution)
+        print(f"Links on path: {links}")
+
+        # Make a flat list of links in connection solution dict, and
+        # check that we have the same number of links.
+        values = sum([v for v in solution.connection_map.values()], [])
+        self.assertEqual(len(links), len(values))
+
+        breakdown = temanager.generate_connection_breakdown(
+            solution, connection_request
+        )
+        print(f"breakdown: {json.dumps(breakdown)}")
+
+        # Note that the "domain" key is correct in the breakdown
+        # result when we initialize TEManager with None for topology,
+        # and later add individual topologies with add_topology().
+        zaoxi = breakdown.get("urn:sdx:topology:zaoxi.net")
+        sax = breakdown.get("urn:sdx:topology:sax.net")
+        amlight = breakdown.get("urn:sdx:topology:amlight.net")
+
+        for segment in [zaoxi, sax, amlight]:
+            self.assertIsInstance(segment, dict)
+            self.assertIsInstance(segment.get("name"), str)
+            self.assertIsInstance(segment.get("dynamic_backup_path"), bool)
+            self.assertIsInstance(segment.get("uni_a"), dict)
+            self.assertIsInstance(segment.get("uni_a").get("tag"), dict)
+            self.assertIsInstance(segment.get("uni_a").get("tag").get("value"), int)
+            self.assertIsInstance(segment.get("uni_a").get("tag").get("tag_type"), int)
+            self.assertIsInstance(segment.get("uni_a").get("port_id"), str)
+            self.assertIsInstance(segment.get("uni_z"), dict)
+            self.assertIsInstance(segment.get("uni_z").get("tag"), dict)
+            self.assertIsInstance(segment.get("uni_z").get("tag").get("value"), int)
+            self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
+            self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
+
+
     def test_connection_amlight_to_zaoxi_two_identical_requests(self):
         """
         Exercise two identical connection requests.

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -95,6 +95,11 @@ class TopologyManagerTests(unittest.TestCase):
         ]
         self.assertEqual(len(interdomain_links), 4)
 
+        print(f"Writing result to {self.TOPOLOGY_OUT}")
+        pathlib.Path(self.TOPOLOGY_OUT).write_text(
+            json.dumps(topology.to_dict(), indent=4)
+        )
+
     def test_update_topology(self):
         print("Test Topology Update!")
 
@@ -127,9 +132,9 @@ class TopologyManagerTests(unittest.TestCase):
         print(f"xml: {xml}")
         self.assertIsNotNone(xml)
 
-    def test_generate_graph(self):
+    def test_generate_graph_v2(self):
         print("Test Topology Graph")
-        self.test_merge_topology()
+        self.test_merge_topology_v2()
         graph = self.topology_manager.generate_graph()
 
         # pos = nx.spring_layout(graph, seed=225)  # Seed for reproducible layout


### PR DESCRIPTION
A new unit test, fix the bug with the corresponding test json in datamodel (3.0.0.dev1)