### PR TITLE
231 vlan continuity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,31 @@ src_paths = ["src", "tests", "scripts"]
 [tool.coverage.run]
 branch = true
 # source_pkgs = sdx.pce
-omit = [ "tests/*" ]
+omit = [ 
+    "tests/*",
+    "*/logger.*",  # Exclude all lines containing 'logger' 
+    "*/logging.*", # Exclude all lines containing 'logging' 
+ ]
 relative_files = true
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "if self\\.debug",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+    ]
 
 # The section below will let us have relative paths in test coverage
 # report. See https://hynek.me/articles/testing-packaging/

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -629,7 +629,7 @@ class TEManager:
 
         # Return a dict containing VLAN-tagged breakdown in the
         # expected format.
-        return tagged_breakdown.to_dict().get("breakdowns")
+        return tagged_breakdown.to_dict().get("breakdowns"), "Breakdowns Succeeded"
 
     def _get_ports_by_link(self, link: ConnectionPath):
         """

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -741,6 +741,8 @@ class TEManager:
 
         breakdowns = {}
         i = 0
+        upstream_egress_vlan = None
+        downstream_ingress_vlan = None
         for domain, segment in domain_breakdown.items():
 
             # These are topology ports

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -478,6 +478,7 @@ class TEManager:
         # may lead to incorrect results.  Dicts are lexically ordered,
         # and that may break some assumptions about the order in which
         # we form and traverse the breakdown.
+        # From 3.7 onwards: Dictionaries are ordered. The order of insertion is preserved.
 
         # Note: Extra flag to indicate if the connection request is in
         # the format of TrafficMatrix or not.
@@ -700,30 +701,51 @@ class TEManager:
                  each port along a path, or None if failure.
         """
 
-        # # Check if there exist a path of vlan continuity.  This is
+        # ToDo: Check if there exist a path of vlan continuity.  This is
         # # disabled for now, until the simple case is handled.
         # selected_vlan = self.find_vlan_on_path(domain_breakdown)
         # if selected_vlan is not None:
         #     return self._reserve_vlan_on_path(domain_breakdown, selected_vlan)
 
-        # if not, assuming vlan translation on the domain border port
+        # It may be the case that end-to-end VLAN continuity is not necessary
+        # as long as the vlan on the two port in a inter-OXP link is the same.
+        # Currently, we implement a simple algorithm to reserve vlan selected
+        # by the upstream port. This is a temporary solution until we implement
+        # a more efficinet algorithm to reserve vlan on a multi-domain path.
 
         self._logger.info(
             f"reserve_vlan_breakdown: domain_breakdown: {domain_breakdown}"
         )
 
-        breakdowns = {}
+        domain_breakdown_list = list(domain_breakdown.items())
+        domain_breakdown_list_len = len(domain_breakdown_list)
+        common_vlan_on_link = {}  # {domain1: upstream_egress_vlan}
+        for i in range(domain_breakdown_list_len - 1):
+            domain, segment = domain_breakdown_list[i]
+            next_domain, next_segment = domain_breakdown_list[i + 1]
+            self._logger.info(
+                f"Find a common vlan: domain: {domain}, segment: {segment}, next_domain: {next_domain}, next_segment: {next_segment}"
+            )
 
-        # upstream_o_vlan = ""
+            upstream_egress = segment.get("egress_port")
+            downstream_ingress = next_segment.get("ingress_port")
+            upstream_egress_vlan = self._find_common_vlan_on_link(
+                domain, upstream_egress, next_domain, downstream_ingress
+            )
+            self._logger.info(
+                f"upstream_egress_vlan: {upstream_egress_vlan}; upstream_egress: {upstream_egress}; downstream_ingress: {downstream_ingress}"
+            )
+            if upstream_egress_vlan is None:
+                return None
+            common_vlan_on_link[domain] = upstream_egress_vlan
+
+        breakdowns = {}
+        i = 0
         for domain, segment in domain_breakdown.items():
+
             # These are topology ports
             ingress_port = segment.get("ingress_port")
             egress_port = segment.get("egress_port")
-
-            self._logger.debug(
-                f"VLAN reservation: domain: {domain}, "
-                f"ingress_port: {ingress_port}, egress_port: {egress_port}"
-            )
 
             if ingress_port is None or egress_port is None:
                 return None
@@ -741,11 +763,36 @@ class TEManager:
             ):
                 egress_user_port_tag = egress_user_port.get("vlan_range")
 
+            self._logger.info(
+                f"VLAN reservation: domain: {domain}, "
+                f"ingress_port: {ingress_port}, egress_port: {egress_port},"
+                f"ingress_user_port_tag: {ingress_user_port_tag}, egress_user_port_tag: {egress_user_port_tag},"
+                f"upstream_egress_vlan: {upstream_egress_vlan}"
+            )
+
+            if i == 0:  # first domain
+                upstream_egress_vlan = None
+                downstream_ingress_vlan = common_vlan_on_link.get(domain)
+            elif i == domain_breakdown_list_len - 1:  # last domain
+                downstream_ingress_vlan = None
+            else:  # middle domain
+                downstream_ingress_vlan = common_vlan_on_link.get(domain)
+
+            i += 1
+
             ingress_vlan = self._reserve_vlan(
-                domain, ingress_port, request_id, ingress_user_port_tag
+                domain,
+                ingress_port,
+                request_id,
+                ingress_user_port_tag,
+                upstream_egress_vlan,
             )
             egress_vlan = self._reserve_vlan(
-                domain, egress_port, request_id, egress_user_port_tag
+                domain,
+                egress_port,
+                request_id,
+                egress_user_port_tag,
+                downstream_ingress_vlan,
             )
 
             if ingress_vlan is None or egress_vlan is None:
@@ -755,6 +802,8 @@ class TEManager:
                 )
                 self.unreserve_vlan(request_id=request_id)
                 return None
+
+            upstream_egress_vlan = egress_vlan
 
             ingress_port_id = ingress_port["id"]
             egress_port_id = egress_port["id"]
@@ -845,7 +894,45 @@ class TEManager:
         # return domain_breakdown
         assert False, "Not implemented"
 
-    def _reserve_vlan(self, domain: str, port: dict, request_id: str, tag: str = None):
+    def _find_common_vlan_on_link(
+        self, domain, upstream_egress, next_domain, downstream_ingress
+    ):
+        """
+        Find a common VLAN on the inter-domain link.
+
+        This function is used to find a common VLAN on the inter-domain link.
+        """
+        upstream_vlan_table = self._vlan_tags_table.get(domain).get(
+            upstream_egress["id"]
+        )
+        downstream_vlan_table = self._vlan_tags_table.get(next_domain).get(
+            downstream_ingress["id"]
+        )
+
+        common_vlans = set(upstream_vlan_table.keys()).intersection(
+            downstream_vlan_table.keys()
+        )
+
+        for vlan in common_vlans:
+            if (
+                upstream_vlan_table[vlan] is UNUSED_VLAN
+                and downstream_vlan_table[vlan] is UNUSED_VLAN
+            ):
+                return vlan
+
+        self._logger.warning(
+            f"No common VLAN found between {domain} and {next_domain} for ports {upstream_egress['id']} and {downstream_ingress['id']}"
+        )
+        return None
+
+    def _reserve_vlan(
+        self,
+        domain: str,
+        port: dict,
+        request_id: str,
+        tag: str = None,
+        upstream_egress_vlan: str = None,
+    ):
         """
         Find unused VLANs for given domain/port and mark them in-use.
 
@@ -859,6 +946,7 @@ class TEManager:
             preferences.  See the description of "vlan" under
             "Mandatory Attributes" section of the Service Provisioning
             Data Model Specification 1.0 for details.
+        :param upstream_vlan: a string that contains the upstream tag to use
 
             https://sdx-docs.readthedocs.io/en/latest/specs/provisioning-api-1.0.html#mandatory-attributes
         """
@@ -893,6 +981,12 @@ class TEManager:
                 f"Can't find a VLAN table for domain: {domain} port: {port_id}"
             )
             return None
+
+        if tag is None:
+            tag = upstream_egress_vlan
+            self._logger.info(f"tag is None, using the upstream_egress_vlan: {tag}")
+        else:
+            self._logger.info(f"tag is not None, using the tag: {tag}")
 
         if tag in (None, "any"):
             # Find the first available VLAN tag from the table.

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -418,7 +418,7 @@ class TEManager:
         """
         if solution is None or solution.connection_map is None:
             self._logger.warning(f"Can't find a solution: {solution}")
-            return None, "No TE Solution found"
+            return None, "Failed: No TE Solution found"
 
         breakdown = {}
         paths = solution.connection_map  # p2p for now
@@ -629,7 +629,10 @@ class TEManager:
 
         # Return a dict containing VLAN-tagged breakdown in the
         # expected format.
-        return tagged_breakdown.to_dict().get("breakdowns"), "Breakdowns Succeeded"
+        return (
+            tagged_breakdown.to_dict().get("breakdowns"),
+            "Succeeded:tagged breakdowns",
+        )
 
     def _get_ports_by_link(self, link: ConnectionPath):
         """
@@ -735,11 +738,11 @@ class TEManager:
             self._logger.info(
                 f"upstream_egress_vlan: {upstream_egress_vlan}; upstream_egress: {upstream_egress}; downstream_ingress: {downstream_ingress}"
             )
-            if upstream_egress_vlan is None:
-                return (
-                    None,
-                    f"No common VLAN found on the link:{upstream_egress['id']} -> {downstream_ingress['id']}",
-                )
+            # if upstream_egress_vlan is None:
+            #    return (
+            #        None,
+            #        f"Failed: No common VLAN found on the link:{upstream_egress['id']} -> {downstream_ingress['id']}",
+            #    )
             common_vlan_on_link[domain] = upstream_egress_vlan
 
         breakdowns = {}
@@ -806,7 +809,7 @@ class TEManager:
                     f"Can't proceed. Rolling back reservations."
                 )
                 self.unreserve_vlan(request_id=request_id)
-                return None, f"VLAN reservation failed for domain: {domain}"
+                return None, f"Failed: VLAN reservation failed for domain: {domain}"
 
             upstream_egress_vlan = egress_vlan
 
@@ -873,7 +876,7 @@ class TEManager:
 
         return (
             VlanTaggedBreakdowns(breakdowns=breakdowns),
-            "Vlan Researvation Succeeded",
+            "Succeeded: Vlan Researvation",
         )
 
     def _find_vlan_on_path(self, path):

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -873,7 +873,7 @@ class TEManager:
 
         return (
             VlanTaggedBreakdowns(breakdowns=breakdowns),
-            f"Vlan Researvation Succeeded",
+            "Vlan Researvation Succeeded",
         )
 
     def _find_vlan_on_path(self, path):

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -813,9 +813,9 @@ class TEManagerTests(unittest.TestCase):
             breakdown, msg = temanager.generate_connection_breakdown(
                 solution, connection_request
             )
-            json.dumps(breakdown)
+            breakdown_json = json.dumps(breakdown)
 
-            print(f"breakdown: {breakdown}")
+            print(f"breakdown: {breakdown_json}")
             self.assertIsNotNone(breakdown)
 
             breakdowns.add(breakdown)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -65,7 +65,8 @@ class TEManagerTests(unittest.TestCase):
 
     def test_connection_breakdown_none_input(self):
         # Expect no breakdown when input is None.
-        self.assertIsNone(self.temanager.generate_connection_breakdown(None, None))
+        breakdown, msg = self.temanager.generate_connection_breakdown(None, None)
+        self.assertIsNone(breakdown)
 
     def test_connection_breakdown_tm(self):
         # Breaking down a traffic matrix.
@@ -82,7 +83,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown(solution, request)
+        breakdown, msg = self.temanager.generate_connection_breakdown(solution, request)
         print(f"Breakdown: {breakdown}")
         self.assertIsNotNone(breakdown)
         self.assertIsInstance(breakdown, dict)
@@ -108,7 +109,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown(solution, request)
+        breakdown, msg = self.temanager.generate_connection_breakdown(solution, request)
         print(f"Breakdown: {breakdown}")
 
         self.assertIsNotNone(breakdown)
@@ -147,7 +148,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown(solution, request)
+        breakdown, msg = self.temanager.generate_connection_breakdown(solution, request)
         print(f"Breakdown: {breakdown}")
 
         self.assertIsNotNone(breakdown)
@@ -200,7 +201,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsNotNone(solution.connection_map)
         self.assertNotEqual(solution.cost, 0)
 
-        breakdown = self.temanager.generate_connection_breakdown(solution, request)
+        breakdown, msg = self.temanager.generate_connection_breakdown(solution, request)
         print(f"Breakdown: {breakdown}")
 
         sax = breakdown.get("urn:sdx:topology:sax.net")
@@ -227,7 +228,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertEqual(solution.cost, 0)
 
         # If there's no solution, there should be no breakdown either.
-        breakdown = self.temanager.generate_connection_breakdown(solution, request)
+        breakdown, msg = self.temanager.generate_connection_breakdown(solution, request)
         self.assertIsNone(breakdown)
 
     def test_generate_graph_and_connection_with_sax_2_invalid(self):
@@ -386,7 +387,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -432,7 +433,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -531,7 +532,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -666,7 +667,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -729,7 +730,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(solution.connection_map)
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -749,7 +750,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(solution.connection_map)
 
-        breakdown2 = temanager.generate_connection_breakdown(
+        breakdown2, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown2: {json.dumps(breakdown2)}")
@@ -809,7 +810,7 @@ class TEManagerTests(unittest.TestCase):
 
             self.assertIsNotNone(solution.connection_map)
 
-            breakdown = json.dumps(
+            breakdown, msg = json.dumps(
                 temanager.generate_connection_breakdown(solution, connection_request)
             )
 
@@ -859,7 +860,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsInstance(solution1, ConnectionSolution)
         self.assertIsNotNone(solution1.connection_map)
 
-        breakdown1 = temanager.generate_connection_breakdown(
+        breakdown1, msg = temanager.generate_connection_breakdown(
             solution1, connection_request1
         )
         print(f"Breakdown #1: {json.dumps(breakdown1)}")
@@ -880,7 +881,7 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsInstance(solution2, ConnectionSolution)
         self.assertIsNotNone(solution2.connection_map)
 
-        breakdown2 = temanager.generate_connection_breakdown(
+        breakdown2, msg = temanager.generate_connection_breakdown(
             solution2, connection_request2
         )
         print(f"Breakdown #2: {json.dumps(breakdown2)}")
@@ -957,7 +958,7 @@ class TEManagerTests(unittest.TestCase):
                 connection_map={}, cost=None, request_id=traffic_matrix.request_id
             )
             result.connection_map[connection_request] = connection_solution
-            breakdown = temanager.generate_connection_breakdown(
+            breakdown, msg = temanager.generate_connection_breakdown(
                 result, connection_object_map[connection_request]
             )
             temanager._logger.info(
@@ -1001,7 +1002,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(solution.connection_map)
 
-        breakdown1 = temanager.generate_connection_breakdown(
+        breakdown1, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown1: {json.dumps(breakdown1)}")
@@ -1010,7 +1011,7 @@ class TEManagerTests(unittest.TestCase):
         temanager.unreserve_vlan(request_id=connection_request.get("id"))
 
         # Can we get the same breakdown for the same request now?
-        breakdown2 = temanager.generate_connection_breakdown(
+        breakdown2, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown2: {json.dumps(breakdown2)}")
@@ -1019,7 +1020,7 @@ class TEManagerTests(unittest.TestCase):
 
         # If we generate another breakdown without un-reserving any
         # VLANs, the result should be distinct from the previous ones.
-        breakdown3 = temanager.generate_connection_breakdown(
+        breakdown3, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown3: {json.dumps(breakdown3)}")
@@ -1059,7 +1060,7 @@ class TEManagerTests(unittest.TestCase):
         # This hopefully should find a solution.
         self.assertIsNotNone(solution.connection_map)
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -1239,7 +1240,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -1360,7 +1361,7 @@ class TEManagerTests(unittest.TestCase):
         values = sum([v for v in solution.connection_map.values()], [])
         self.assertEqual(len(links), len(values))
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
         print(f"breakdown: {json.dumps(breakdown)}")
@@ -1456,7 +1457,7 @@ class TEManagerTests(unittest.TestCase):
 
         self.assertIsNotNone(solution)
 
-        breakdown = temanager.generate_connection_breakdown(
+        breakdown, msg = temanager.generate_connection_breakdown(
             solution, connection_request
         )
 

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -810,9 +810,10 @@ class TEManagerTests(unittest.TestCase):
 
             self.assertIsNotNone(solution.connection_map)
 
-            breakdown, msg = json.dumps(
-                temanager.generate_connection_breakdown(solution, connection_request)
+            breakdown, msg = temanager.generate_connection_breakdown(
+                solution, connection_request
             )
+            json.dumps(breakdown)
 
             print(f"breakdown: {breakdown}")
             self.assertIsNotNone(breakdown)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -68,6 +68,57 @@ class TEManagerTests(unittest.TestCase):
         breakdown, msg = self.temanager.generate_connection_breakdown(None, None)
         self.assertIsNone(breakdown)
 
+    def test_find_common_vlan_on_link(self):
+        """
+        Test the _find_common_vlan_on_link() method.
+        """
+        # Load topologies
+        sax_topology = json.loads(TestData.TOPOLOGY_FILE_SAX.read_text())
+        zaoxi_topology = json.loads(TestData.TOPOLOGY_FILE_ZAOXI.read_text())
+
+        # Initialize TEManager and add topologies
+        temanager = TEManager(topology_data=None)
+        temanager.add_topology(sax_topology)
+        temanager._update_vlan_tags_table(
+            domain_name=sax_topology.get("id"),
+            port_map=temanager.topology_manager.get_port_map(),
+        )
+
+        temanager.add_topology(zaoxi_topology)
+        temanager._update_vlan_tags_table(
+            domain_name=zaoxi_topology.get("id"),
+            port_map=temanager.topology_manager.get_port_map(),
+        )
+
+        # Define test cases
+        test_cases = [
+            {
+                "domain": "urn:sdx:topology:sax.net",
+                "upstream_egress": "urn:sdx:port:sax:B3:1",
+                "next_domain": "urn:sdx:topology:zaoxi.net",
+                "downstream_ingress": "urn:sdx:port:zaoxi:B1:1",
+                "expected_vlan": 100,  # Example expected VLAN
+            },
+            #
+            {
+                "domain": "urn:sdx:topology:sax.net",
+                "upstream_egress": "urn:sdx:port:sax.net:SAX2:1",
+                "next_domain": "urn:sdx:topology:zaoxi.net",
+                "downstream_ingress": "urn:sdx:port:zaoxi.net:ZAOXI2:1",
+                "expected_vlan": None,  # Example expected VLAN when no common VLAN exists
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(case=case):
+                common_vlan = temanager._find_common_vlan_on_link(
+                    case["domain"],
+                    case["upstream_egress"],
+                    case["next_domain"],
+                    case["downstream_ingress"],
+                )
+                self.assertEqual(common_vlan, case["expected_vlan"])
+
     def test_connection_breakdown_tm(self):
         # Breaking down a traffic matrix.
         request = [

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -813,12 +813,13 @@ class TEManagerTests(unittest.TestCase):
             breakdown, msg = temanager.generate_connection_breakdown(
                 solution, connection_request
             )
+            self.assertIsNotNone(breakdown)
+
             breakdown_json = json.dumps(breakdown)
 
             print(f"breakdown: {breakdown_json}")
-            self.assertIsNotNone(breakdown)
 
-            breakdowns.add(breakdown)
+            breakdowns.add(breakdown_json)
 
             graph = TESolver(graph, traffic_matrix).update_graph(graph, solution)
 


### PR DESCRIPTION
Implemented a _find_common_vlan method:

On a breakdown path, it will find the common vlan (first fit) between the two NNI ports. Otherwise, it will return a None and fail the provisioning.

Note: This is not end-to-end path vlan continuity.