### PR TITLE
Save/restore vlan reservations

### DIFF
--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -154,6 +154,18 @@ class TEManager:
                 if not isinstance(labels, dict):
                     raise ValidationError(f"labels ({labels}) is not a dict")
 
+        # We should allow VLAN table to be restored only during
+        # startup.  If the table has VLANs that are in use, it means
+        # that we're in the wrong state.
+        for domain, ports in self._vlan_tags_table.items():
+            for port_id, labels in ports.items():
+                for vlan, status in labels.items():
+                    if status is not UNUSED_VLAN:
+                        raise ValidationError(
+                            f"Error: VLAN table is not empty:"
+                            f"(domain: {domain}, port: {port}, vlan: {vlan})"
+                        )
+
         self._vlan_tags_table = table
 
     def _update_vlan_tags_table(self, domain_name: str, port_map: dict):

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -139,6 +139,7 @@ class TEManager:
         """
         Set VLAN tags table.
         """
+        # TODO: validate the table, perhaps?
         self._vlan_tags_table = table
 
     def _update_vlan_tags_table(self, domain_name: str, port_map: dict):

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -1023,8 +1023,8 @@ class TEManager:
         domain: str,
         port: dict,
         request_id: str,
-        tag: str = None,
-        upstream_egress_vlan: str = None,
+        tag: Optional[str] = None,
+        upstream_egress_vlan: Optional[str] = None,
     ):
         """
         Find unused VLANs for given domain/port and mark them in-use.
@@ -1170,7 +1170,7 @@ class TEManager:
         # Now it is the time to update the bandwidth of the links after breakdowns are successfully generated
         self.update_link_bandwidth(solution, reduce=False)
 
-    def get_connection_solution(self, request_id: str) -> ConnectionSolution:
+    def get_connection_solution(self, request_id: str) -> Optional[ConnectionSolution]:
         """
         Get a connection solution by request ID.
         """

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -163,7 +163,7 @@ class TEManager:
                     if status is not UNUSED_VLAN:
                         raise ValidationError(
                             f"Error: VLAN table is not empty:"
-                            f"(domain: {domain}, port: {port}, vlan: {vlan})"
+                            f"(domain: {domain}, port: {port_id}, vlan: {vlan})"
                         )
 
         self._vlan_tags_table = table

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -139,7 +139,21 @@ class TEManager:
         """
         Set VLAN tags table.
         """
-        # TODO: validate the table, perhaps?
+        # Ensure that the input is in correct shape.
+        if not isinstance(table, dict):
+            raise ValidationError(f"table ({table}) is not a dict")
+
+        for domain, ports in table.items():
+            if not isinstance(domain, str):
+                raise ValidationError(f"domain ({domain}) is not a str")
+
+            for port_id, labels in ports.items():
+                if not isinstance(port_id, str):
+                    raise ValidationError(f"port_id ({port_id}) is not a str")
+
+                if not isinstance(labels, dict):
+                    raise ValidationError(f"labels ({labels}) is not a dict")
+
         self._vlan_tags_table = table
 
     def _update_vlan_tags_table(self, domain_name: str, port_map: dict):

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -127,6 +127,20 @@ class TEManager:
             connections.append(solution.request_id)
         return connections
 
+    @property
+    def vlan_tags_table(self) -> dict:
+        """
+        Return the current VLAN tags table.
+        """
+        return self._vlan_tags_table
+
+    @vlan_tags_table.setter
+    def vlan_tags_table(self, table: dict):
+        """
+        Set VLAN tags table.
+        """
+        self._vlan_tags_table = table
+
     def _update_vlan_tags_table(self, domain_name: str, port_map: dict):
         """
         Update VLAN tags table in a non-disruptive way, meaning: only add new

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1815,3 +1815,26 @@ class TEManagerTests(unittest.TestCase):
             return requested_vlan in requested_range
 
         raise Exception("invalid state!")
+
+    def test_vlan_tags_table(self):
+        """
+        Test saving/restoring VLAN tags table.
+        """
+        temanager = TEManager(topology_data=None)
+
+        for topology_file in [
+            TestData.TOPOLOGY_FILE_AMLIGHT_v2,
+            TestData.TOPOLOGY_FILE_ZAOXI_v2,
+            TestData.TOPOLOGY_FILE_SAX_v2,
+        ]:
+            temanager.add_topology(json.loads(topology_file.read_text()))
+
+        # Test getter.
+        table1 = temanager.vlan_tags_table
+        self.assertIsInstance(table1, dict)
+
+        # Test setter
+        temanager.vlan_tags_table = table1
+        table2 = temanager.vlan_tags_table
+        self.assertIsInstance(table2, dict)
+        self.assertEqual(table1, table2)

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1905,6 +1905,9 @@ class TEManagerTests(unittest.TestCase):
             solution, connection_request
         )
 
+        print(f"Breakdown: {breakdown}")
+        self.assertIsNotNone(breakdown)
+
         # The VLAN table should have some allocations now, and we
         # should not be able to change its state.
         with self.assertRaises(ValidationError) as ctx:


### PR DESCRIPTION
Resolves #215. The API is really simple, and is implemented using [`@property`](https://docs.python.org/3/library/functions.html#property):

```python
# Get the current VLAN allocation table.
vlan_table = temanager.vlan_tags_table

# Restore VLAN allocation table.
temanager.vlan_tags_table = vlan_table
```

We do some checks in the setter, such as: the input data is in the expected shape, and that we have no existing allocations.  The assumption is that SDX Controller would attempt to restore VLAN allocation state only during startup.