### PR TITLE
Fixes for OXP domains and fix test on breakdowns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@fix/issue_182",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@3.0.0.dev8",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@3.0.0.dev7",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@fix/issue_182",
 ]
 
 [project.urls]

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -282,7 +282,7 @@ class TEManager:
                                 ranges.append(f"{start}")
                             else:
                                 ranges.append(f"{start}-{end}")
-                                start = end = vlan
+                            start = end = vlan
                     if start == end:
                         ranges.append(f"{start}")
                     else:

--- a/tests/data/test_request_amlight_zaoxi_user_port.json
+++ b/tests/data/test_request_amlight_zaoxi_user_port.json
@@ -11,9 +11,9 @@
         "vlan_range": "150"
     },
     "ingress_port": {
-        "id": "urn:sdx:port:zaoxi:B2:1",
+        "id": "urn:sdx:port:zaoxi.net:B2:1",
         "name": "Novi100:2",
-        "node": "urn:sdx:node:zaoxi:B2",
+        "node": "urn:sdx:node:zaoxi.net:B2",
         "status": "up",
         "vlan_range": "160"
     }

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -86,9 +86,9 @@ class TEManagerTests(unittest.TestCase):
         test_cases = [
             {
                 "domain": "urn:sdx:topology:sax.net",
-                "upstream_egress": "urn:sdx:port:sax:B3:1",
+                "upstream_egress": "urn:sdx:port:sax.net:B3:1",
                 "next_domain": "urn:sdx:topology:zaoxi.net",
-                "downstream_ingress": "urn:sdx:port:zaoxi:B1:1",
+                "downstream_ingress": "urn:sdx:port:zaoxi.net:B1:1",
                 "expected_vlan": 100,  # Example expected VLAN
             },
             #
@@ -214,9 +214,7 @@ class TEManagerTests(unittest.TestCase):
 
         request = [
             {
-                "1": [[1, 2], [3, 4]],
-                "2": [[1, 2], [3, 5]],
-                "3": [[7, 8], [8, 9]],
+                "1": [[2, 9]],
             },
             1.0,
         ]
@@ -232,11 +230,8 @@ class TEManagerTests(unittest.TestCase):
         self.assertIsInstance(breakdown, dict)
         self.assertEqual(len(breakdown), 3)
 
-        amlight = breakdown.get("urn:sdx:topology:amlight.net")
-        zaoxi = breakdown.get("urn:sdx:topology:zaoxi.net")
-        sax = breakdown.get("urn:sdx:topology:sax.net")
-
-        for segment in [zaoxi, sax, amlight]:
+        for domain in ["amlight.net", "zaoxi.net", "sax.net"]:
+            segment = breakdown.get(f"urn:sdx:topology:{domain}")
             self.assertIsInstance(segment, dict)
             self.assertIsInstance(segment.get("name"), str)
             self.assertIsInstance(segment.get("dynamic_backup_path"), bool)
@@ -250,6 +245,9 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("value"), int)
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
+            self.assertTrue(segment["uni_a"]["port_id"].startswith(f"urn:sdx:port:{domain}"))
+            self.assertTrue(segment["uni_z"]["port_id"].startswith(f"urn:sdx:port:{domain}"))
+            self.assertNotEqual(segment["uni_a"]["port_id"], segment["uni_z"]["port_id"])
 
     def test_connection_breakdown_three_domains_sax_connection(self):
         """
@@ -1635,7 +1633,7 @@ class TEManagerTests(unittest.TestCase):
                         "vlan": "777"
                     },
                     {
-                        "port_id": "urn:sdx:port:amlight:B1:1",
+                        "port_id": "urn:sdx:port:amlight.net:B1:1",
                         "vlan": "777"
                     }
                 ]

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -1,6 +1,7 @@
 import json
 import pprint
 import unittest
+from unittest.mock import MagicMock
 
 import networkx as nx
 
@@ -2156,3 +2157,45 @@ class TEManagerTests(unittest.TestCase):
 
         low, high = sax_port.services.l2vpn_ptp["vlan_range"][0].split("-")
         self.assertTrue(int(low) <= 1 <= int(high))
+
+    def test_update_available_vlans_basic_checks(self):
+        """
+        Test the update_available_vlans() method with basic checks.
+        """
+        te = TEManager(topology_data=None)
+        te.topology_manager = MagicMock()
+        result = te.update_available_vlans(
+            {
+                "d1": {
+                    "p1": {
+                        1: None,
+                        2: None,
+                        3: None,
+                        4: True,
+                        5: None,
+                        6: True,
+                        7: None,
+                        8: None,
+                        9: None,
+                    },
+                },
+            },
+        )
+        self.assertEqual(result, {"d1": {"p1": ["1-3", "5", "7-9"]}})
+        result = te.update_available_vlans(
+            {
+                "d1": {
+                    "p1": {
+                        1: True,
+                        2: None,
+                        3: None,
+                        4: True,
+                        5: None,
+                        6: True,
+                        7: True,
+                        8: True,
+                    },
+                },
+            },
+        )
+        self.assertEqual(result, {"d1": {"p1": ["2-3", "5"]}})

--- a/tests/test_te_manager.py
+++ b/tests/test_te_manager.py
@@ -245,9 +245,15 @@ class TEManagerTests(unittest.TestCase):
             self.assertIsInstance(segment.get("uni_z").get("tag").get("value"), int)
             self.assertIsInstance(segment.get("uni_z").get("tag").get("tag_type"), int)
             self.assertIsInstance(segment.get("uni_z").get("port_id"), str)
-            self.assertTrue(segment["uni_a"]["port_id"].startswith(f"urn:sdx:port:{domain}"))
-            self.assertTrue(segment["uni_z"]["port_id"].startswith(f"urn:sdx:port:{domain}"))
-            self.assertNotEqual(segment["uni_a"]["port_id"], segment["uni_z"]["port_id"])
+            self.assertTrue(
+                segment["uni_a"]["port_id"].startswith(f"urn:sdx:port:{domain}")
+            )
+            self.assertTrue(
+                segment["uni_z"]["port_id"].startswith(f"urn:sdx:port:{domain}")
+            )
+            self.assertNotEqual(
+                segment["uni_a"]["port_id"], segment["uni_z"]["port_id"]
+            )
 
     def test_connection_breakdown_three_domains_sax_connection(self):
         """

--- a/tests/test_topology_manager.py
+++ b/tests/test_topology_manager.py
@@ -33,8 +33,8 @@ class TopologyManagerTests(unittest.TestCase):
     ]
     TOPOLOGY_FILE_LIST_UPDATE = [TestData.TOPOLOGY_FILE_SAX_v2_UPDATE]
 
-    LINK_ID = "urn:sdx:link:amlight:B1-B2"
-    INTER_LINK_ID = "urn:sdx:link:zaoxi:A1-B2"
+    LINK_ID = "urn:sdx:link:amlight.net:B1-B2"
+    INTER_LINK_ID = "urn:sdx:link:zaoxi.net:A1-B2"
 
     def setUp(self):
         self.topology_manager = TopologyManager()


### PR DESCRIPTION
Fix #276 

Related to https://github.com/atlanticwave-sdx/datamodel/issues/182

### Description of the changes

This PR has two main contributions:

- Enhancements for comply with datamodel recent adjustments related to OXP domains (https://github.com/atlanticwave-sdx/datamodel/pull/183)
- Fix test on breakdowns calculation (#276)