### PR TITLE
Fix topology update process and return code when validating L2VPN requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "prtpy",
     "pydot",
     "dataclasses-json",
-    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@fix/issue_182",
+    "sdx-datamodel @ git+https://github.com/atlanticwave-sdx/datamodel@3.0.0.dev8",
 ]
 
 [project.urls]

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -676,43 +676,6 @@ class TopologyManager:
         # If it's bandwdith, we need to update the residual bandwidth as a percentage
         # "bandwidth" remains to keep the original port bandwidth in topology json.
         # in the graph model, linkd bandwidth is computed as bandwidth*residual_bandwidth*0.01
-        # 1. update the individual topology
-        for id, topology in self._topology_map.items():
-            link = topology.get_link_by_port_id(port_id_0, port_id_1)
-            if link is not None:
-                orignial_bw = link.__getattribute__(Constants.BANDWIDTH)
-                residual = link.__getattribute__(property)
-                if property == Constants.RESIDUAL_BANDWIDTH:
-                    if replace is False:
-                        residual_bw = (
-                            link.__getattribute__(Constants.BANDWIDTH) * residual * 0.01
-                        )
-                        self._logger.info(
-                            "updated the link:"
-                            + str(residual_bw)
-                            + " value:"
-                            + str(value)
-                        )
-                        new_residual = max(
-                            (residual_bw + value) * 100 / orignial_bw, 0.001
-                        )
-                    else:
-                        new_residual = value
-                    setattr(link, property, new_residual)
-                    self._logger.info(
-                        "updated the link:"
-                        + link._id
-                        + ":"
-                        + property
-                        + " from "
-                        + str(residual)
-                        + " to "
-                        + str(new_residual)
-                    )
-                # 1.2 need to change the sub_ver of the topology?
-
-        # 2. check on the inter-domain link?
-        # update the interdomain topology
         link = self._topology.get_link_by_port_id(port_id_0, port_id_1)
         if link is not None:
             orignial_bw = link.__getattribute__(Constants.BANDWIDTH)
@@ -736,7 +699,6 @@ class TopologyManager:
                     + " to "
                     + str(new_residual)
                 )
-            # 2.2 need to change the sub_ver of the topology?
 
     def change_port_vlan_range(self, topology_id, port_id, value):
         topology = self._topology_map.get(topology_id)

--- a/src/sdx_pce/topology/manager.py
+++ b/src/sdx_pce/topology/manager.py
@@ -385,12 +385,12 @@ class TopologyManager:
         self._topology_map[topology.id] = topology
 
         # Nodes.
-        nodes = topology.nodes
+        nodes = old_topology.nodes
         for node in nodes:
             self._topology.remove_node(node.id)
 
         # Links.
-        links = topology.links
+        links = old_topology.links
         for link in links:
             if not self.is_link_interdomain(link, topology):
                 # print(link.id+";......."+str(link.nni))

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -133,11 +133,13 @@ class TEManager:
 
             # Update available VLANs in topology with current states
             self.update_available_vlans(vlan_tags_table)
-            self.update_available_bw_in_topology(residul_bw)
         else:
             self._logger.info(
                 "temanager:No node and link changes detected in the topology"
             )
+
+        # Fix residual bandwidth after update the topology
+        self.update_available_bw_in_topology(residul_bw)
 
         return (
             removed_nodes_list,

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -10,6 +10,7 @@ from networkx.algorithms import approximation as approx
 from sdx_datamodel.models.port import Port
 from sdx_datamodel.parsing.connectionhandler import ConnectionHandler
 from sdx_datamodel.parsing.exceptions import (
+    AttributeNotSupportedException,
     MissingAttributeException,
     ServiceNotSupportedException,
 )
@@ -427,6 +428,11 @@ class TEManager:
             self._logger.error(f"Service not supported: {e} for {connection_request}")
             raise RequestValidationError(
                 f"Validation error: {e} for {connection_request}", 402
+            )
+        except AttributeNotSupportedException as e:
+            self._logger.error(f"Attribute not supported: {e} for {connection_request}")
+            raise RequestValidationError(
+                f"Attribute not supported: {e} for {connection_request}", 422
             )
         except Exception as e:
             err = traceback.format_exc().replace("\n", ", ")

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -506,16 +506,16 @@ class TEManager:
         ]
 
         if len(ingress_nodes) <= 0:
-            self._logger.warning(
-                f"No ingress node '{ingress_node.id}' found in the graph"
+            raise RequestValidationError(
+                f"No path available between endpoints: {ingress_node.id} not found in the graph",
+                412,
             )
-            return None
 
         if len(egress_nodes) <= 0:
-            self._logger.warning(
-                f"No egress node '{egress_node.id}' found in the graph"
+            raise RequestValidationError(
+                f"No path available between endpoints: {egress_node.id} not found in the graph",
+                412,
             )
-            return None
 
         required_bandwidth = request.bandwidth_required or 0
         required_latency = request.latency_required or float("inf")


### PR DESCRIPTION
Fix atlanticwave-sdx/sdx-controller#448
Fix atlanticwave-sdx/sdx-controller#449
Fix atlanticwave-sdx/sdx-controller#342
Fix atlanticwave-sdx/sdx-end-to-end-tests#56
Fix atlanticwave-sdx/sdx-end-to-end-tests#55
Fix atlanticwave-sdx/sdx-end-to-end-tests#53
Fix atlanticwave-sdx/sdx-end-to-end-tests#49

Heads-up: this PR will sit on top of #283 

### Description of the change

This PR apply some fixes and enhances on PCE to better handle topology updates and L2VPN request validations to provide proper return codes. Improvements are listed below:

- On topology updates, some fixes were applied to guarantee that residual_bandwidth local changes will be applied to all links after applying the changes to the SDX-Controller data. As discussed on Issue #286, the `Link.residual_bandwidth` is being used by SDX-Controller with a semantic overload, meaning: it is being used for OXPs to report their bandwidth usage statistics (as described in the Topology Data Model Spec 2.0) but it is also being used by SDX-Controller to account for reserved bandwidth requests (`L2VPN.qos_metrics.min_bw`). Thus, the SDX-Controller updates that attribute decreasing/increasing BW upon creating/deleting L2VPN with min_bw. The routine was there but being applied in a wrong place (i.e., only when links/nodes were added/removed, while it should be all the time the topology is updated)

- On topology updates, links and nodes were not being removed due to a bug on the code that remove the updated items, instead of the old ones

- On topology updates, remove duplicated code that process link property updates, which ended up setting a wrong value on the link property.

- L2VPN request validations were being applied but wrong Exceptions were being generated back to connection handler, to properly return to the user

- L2VPN request handler were returning None when the ingress/egress node were not in the generated graph, while it should raise an exception of path not found since the ingress/egress port ID were previous validated beforehand. Thus, at that point the ingress/egress nodes were not in the graph because they were not connected to the graph, meaning Path Not Found (return code 412, instead of 400).



### End-to-End tests

End-to-End tests were executed using the branch of this PR and results were positive:

```
~/sdx-end-to-end-tests$ git diff docker-compose.yml
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b430f2..4674937 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./pce/src/sdx_pce:/opt/venv/lib/python3.11/site-packages/sdx_pce
     depends_on:
       mongo:
         condition: service_healthy
~/sdx-end-to-end-tests$ cd pce/
~/sdx-end-to-end-tests/pce$ git status
On branch fix/issue_controller_448
Your branch is up to date with 'origin/fix/issue_controller_448'.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
~/sdx-end-to-end-tests/pce$ cd ..
$ cat run-all.sh
TESTS=tests/
docker compose down -v; docker compose up -d; ./wait-mininet-ready.sh; docker compose exec -it mininet python3 -m pytest $TESTS
$ for i in $(seq 1 5); do bash -x run-all.sh ; done
...
+ docker compose exec -it mininet python3 -m pytest tests/
================================= test session starts =======================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.6.1
collected 79 items

tests/test_01_topology.py .....                                                                                                                                                 [  6%]
tests/test_05_l2vpn.py .......X                                                                                                                                                 [ 16%]
tests/test_06_l2vpn_return_codes.py .....X.......................x.XXX                                                                                        [ 59%]
tests/test_07_l2vpn_return_codes.py ...............X......X                                                                                                        [ 88%]
tests/test_08_l2vpn_return_codes.py ......                                                                                                                            [ 96%]
tests/test_99_topology_big_changes.py .X.                                                                                                                         [100%]

------------------------------------------- start/stop times -------------------------------------------
================= 70 passed, 1 xfailed, 8 xpassed in 765.57s (0:12:45) ===========================
...
====== 70 passed, 1 xfailed, 8 xpassed in 759.79s (0:12:39) ======
...
====== 70 passed, 1 xfailed, 8 xpassed in 758.14s (0:12:38) ======
....
====== 70 passed, 1 xfailed, 8 xpassed in 764.31s (0:12:44) ======
...
====== 70 passed, 1 xfailed, 8 xpassed in 774.73s (0:12:54) ======
```

As can be noticed above, 8 tests are now passing due to the fixes of this PR.

### Local tests

After applying the changes on this PR plus PR #283 , the results are very consistent and no unexpected error:

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "300"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "300"}], "qos_metrics": {"min_bw": {"value": 9}}}'
{
  "reason": "Connection published",
  "service_id": "f6afb238-10de-4b21-9fb3-1c2dbe7fe4b8",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 100
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 100
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 10
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 100
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 10
urn:sdx:link:sax.net:Sax01/1_Sax02/1 100
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 100
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 100
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 100
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 10

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "301"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "301"}], "qos_metrics": {"min_bw": {"value": 9}}}'
{
  "reason": "Connection published",
  "service_id": "2593f8e6-0491-4770-a1fd-d7f335ca0dbb",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 10
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 100
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 10
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 10
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 10
urn:sdx:link:sax.net:Sax01/1_Sax02/1 100
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 10
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 100
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 10
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 10

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "302"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "302"}], "qos_metrics": {"min_bw": {"value": 9}}}'
{
  "reason": "Connection published",
  "service_id": "6b63c6f0-2597-472e-8923-bde109ced6e6",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 10
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 10
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 10
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 10
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 10
urn:sdx:link:sax.net:Sax01/1_Sax02/1 100
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 10
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 100
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 10
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 10

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "303"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "303"}], "qos_metrics": {"min_bw": {"value": 9}}}'
{
  "reason": "Connection published",
  "service_id": "55968fc9-53ec-4201-8032-d404773ed4fb",
  "status": "under provisioning"
}

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "304"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "304"}], "qos_metrics": {"min_bw": {"value": 9}}}'
{
  "reason": "Connection published",
  "service_id": "aa46a6c1-dc8f-416d-bfcf-6cefe6c5984c",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 10
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 10
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 10
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 10
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 10
urn:sdx:link:sax.net:Sax01/1_Sax02/1 10
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 10
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 10
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 10
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 10

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "305"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "305"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Connection published",
  "service_id": "63cfe562-4df4-4cb6-9c8b-46aa18c3e11c",
  "status": "under provisioning"
}

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "306"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "306"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Connection published",
  "service_id": "d08216af-34ae-432c-a761-82d622df0673",
  "status": "under provisioning"
}

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "307"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "307"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Connection published",
  "service_id": "4d531bad-eacf-4be4-85cc-74ed0294c61a",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 0.001
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 0.001
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 0.001
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 0.001
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 0.001
urn:sdx:link:sax.net:Sax01/1_Sax02/1 10
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 0.001
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 10
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 0.001
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 0.001

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "308"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "308"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Connection published",
  "service_id": "088db6ec-f533-4a5d-bb4e-13af079dbf16",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 0.001
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 0.001
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 0.001
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 0.001
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 0.001
urn:sdx:link:sax.net:Sax01/1_Sax02/1 0.001
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 0.001
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 10
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 0.001
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 0.001

$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "308"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "309"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Connection published",
  "service_id": "bd4030dc-7705-4f28-a0a1-f9a94aaad6c7",
  "status": "under provisioning"
}

$ curl -s http://0.0.0.0:8080/SDX-Controller/topology | jq -r '.links[]| .id + " " + (.residual_bandwidth|tostring)'
urn:sdx:link:ampath.net:Ampath2/3_Ampath3/3 0.001
urn:sdx:link:ampath.net:Ampath1/1_Ampath2/1 0.001
urn:sdx:link:ampath.net:Ampath1/2_Ampath3/2 0.001
urn:sdx:link:interdomain:ampath.net:Ampath2:40:sax.net:Sax02:40 0.001
urn:sdx:link:interdomain:ampath.net:Ampath1:40:sax.net:Sax01:40 0.001
urn:sdx:link:sax.net:Sax01/1_Sax02/1 0.001
urn:sdx:link:tenet.ac.za:Tenet01/1_Tenet02/1 0.001
urn:sdx:link:tenet.ac.za:Tenet01/2_Tenet03/2 0.001
urn:sdx:link:interdomain:sax.net:Sax02:41:tenet.ac.za:Tenet02:41 0.001
urn:sdx:link:interdomain:sax.net:Sax01:41:tenet.ac.za:Tenet01:41 0.001
```

All requests worked as expected. At this point, almost no bandwidth is available on the links. To make sure PCE is giving the expected result, I tried to create new L2VPNs with min_bw (expected behavior: failure):

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "399"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "399"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Could not solve the request",
  "service_id": "e2e1d3e2-728f-4c2c-89b8-593f5bd06d38",
  "status": "error"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "399"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "399"}], "qos_metrics": {"min_bw": {"value": 3}}}'
{
  "reason": "Could not solve the request",
  "service_id": "8121cde7-8d4d-4800-a36c-43506b493983",
  "status": "error"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "399"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "399"}], "qos_metrics": {"min_bw": {"value": 5}}}'
{
  "reason": "Could not solve the request",
  "service_id": "4bc822cd-dcf3-4a9b-ae62-6071b8766057",
  "status": "error"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "399"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "399"}], "qos_metrics": {"min_bw": {"value": 8}}}'
{
  "reason": "Could not solve the request",
  "service_id": "c856b719-4928-47b3-b1a4-071ae2eb49dc",
  "status": "error"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "399"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "399"}], "qos_metrics": {"min_bw": {"value": 1}}}'
{
  "reason": "Could not solve the request",
  "service_id": "b12a7a9e-cbeb-4126-b893-c52104fbe23f",
  "status": "error"
}
```

Finally, requesting L2VPNs without min_bw QoS requirements should work just fine:

```
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "401"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "401"}]}'
{
  "reason": "Connection published",
  "service_id": "ea12aac0-44ca-44f7-9ed7-08082c836768",
  "status": "under provisioning"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "402"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "402"}]}'
{
  "reason": "Connection published",
  "service_id": "f6f6f770-72e4-494e-8c96-6f8f41408c30",
  "status": "under provisioning"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath1:50", "vlan": "403"}, {"port_id": "urn:sdx:port:ampath.net:Ampath2:50", "vlan": "403"}]}'
{
  "reason": "Connection published",
  "service_id": "bcb0544b-666d-4c10-9d02-bf192360b4c5",
  "status": "under provisioning"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:sax.net:Sax01:50", "vlan": "404"}, {"port_id": "urn:sdx:port:sax.net:Sax02:50", "vlan": "404"}]}'
{
  "reason": "Connection published",
  "service_id": "add8e7f7-4fbf-4f8b-8e39-31b61e3996d8",
  "status": "under provisioning"
}
$ curl -s -X POST -H 'Content-type: application/json' http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 -d '{"name": "VLAN-Test", "endpoints": [{"port_id": "urn:sdx:port:tenet.ac.za:Tenet01:50", "vlan": "405"}, {"port_id": "urn:sdx:port:tenet.ac.za:Tenet03:50", "vlan": "405"}]}'
{
  "reason": "Connection published",
  "service_id": "d627da1e-ac17-4cc2-ac5a-c0b36a7ad09c",
  "status": "under provisioning"
}
```

ALl L2vpns are UP:

```
$ ./show-sdx-controller.sh l2vpn
ID                                    STATUS  ENDPOINT-1                           VLAN-1  ENDPOINT-2                           VLAN-2
--                                    ------  ----------                           ------  ----------                           ------
088db6ec-f533-4a5d-bb4e-13af079dbf16  up      urn:sdx:port:sax.net:Sax01:50        308     urn:sdx:port:sax.net:Sax02:50        308
2593f8e6-0491-4770-a1fd-d7f335ca0dbb  up      urn:sdx:port:ampath.net:Ampath3:50   301     urn:sdx:port:tenet.ac.za:Tenet01:50  301
4d531bad-eacf-4be4-85cc-74ed0294c61a  up      urn:sdx:port:ampath.net:Ampath1:50   307     urn:sdx:port:ampath.net:Ampath2:50   307
55968fc9-53ec-4201-8032-d404773ed4fb  up      urn:sdx:port:sax.net:Sax01:50        303     urn:sdx:port:sax.net:Sax02:50        303
63cfe562-4df4-4cb6-9c8b-46aa18c3e11c  up      urn:sdx:port:ampath.net:Ampath3:50   305     urn:sdx:port:tenet.ac.za:Tenet01:50  305
6b63c6f0-2597-472e-8923-bde109ced6e6  up      urn:sdx:port:ampath.net:Ampath1:50   302     urn:sdx:port:ampath.net:Ampath2:50   302
aa46a6c1-dc8f-416d-bfcf-6cefe6c5984c  up      urn:sdx:port:tenet.ac.za:Tenet01:50  304     urn:sdx:port:tenet.ac.za:Tenet03:50  304
add8e7f7-4fbf-4f8b-8e39-31b61e3996d8  up      urn:sdx:port:sax.net:Sax01:50        404     urn:sdx:port:sax.net:Sax02:50        404
bcb0544b-666d-4c10-9d02-bf192360b4c5  up      urn:sdx:port:ampath.net:Ampath1:50   403     urn:sdx:port:ampath.net:Ampath2:50   403
bd4030dc-7705-4f28-a0a1-f9a94aaad6c7  up      urn:sdx:port:tenet.ac.za:Tenet01:50  308     urn:sdx:port:tenet.ac.za:Tenet03:50  309
d08216af-34ae-432c-a761-82d622df0673  up      urn:sdx:port:ampath.net:Ampath3:50   306     urn:sdx:port:tenet.ac.za:Tenet01:50  306
d627da1e-ac17-4cc2-ac5a-c0b36a7ad09c  up      urn:sdx:port:tenet.ac.za:Tenet01:50  405     urn:sdx:port:tenet.ac.za:Tenet03:50  405
ea12aac0-44ca-44f7-9ed7-08082c836768  up      urn:sdx:port:ampath.net:Ampath3:50   401     urn:sdx:port:tenet.ac.za:Tenet01:50  401
f6afb238-10de-4b21-9fb3-1c2dbe7fe4b8  up      urn:sdx:port:ampath.net:Ampath3:50   300     urn:sdx:port:tenet.ac.za:Tenet01:50  300
f6f6f770-72e4-494e-8c96-6f8f41408c30  up      urn:sdx:port:ampath.net:Ampath3:50   402     urn:sdx:port:tenet.ac.za:Tenet01:50  402
```

Por VLANs are also consistent:

```
$ ./show-sdx-controller.sh ports
ID                                   STATUS  STATE    L2VPN-VLAN-RANGE
--                                   ------  -----    ----------------
urn:sdx:port:ampath.net:Ampath3:2    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath3:50   up      enabled  ["1-299","302-304","307-400","403-4000"]
urn:sdx:port:ampath.net:Ampath3:3    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath2:1    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath2:50   up      enabled  ["1-301","303-306","308-402","404-4000"]
urn:sdx:port:ampath.net:Ampath2:40   up      enabled  ["3-4094"]
urn:sdx:port:ampath.net:Ampath2:3    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath1:1    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath1:40   up      enabled  ["5-4094"]
urn:sdx:port:ampath.net:Ampath1:2    up      enabled  ["1-4094"]
urn:sdx:port:ampath.net:Ampath1:50   up      enabled  ["1-301","303-306","308-402","404-4000"]
urn:sdx:port:sax.net:Sax01:41        up      enabled  ["5-4094"]
urn:sdx:port:sax.net:Sax01:1         up      enabled  ["1-4094"]
urn:sdx:port:sax.net:Sax01:40        up      enabled  ["5-4094"]
urn:sdx:port:sax.net:Sax01:50        up      enabled  ["1-302","304-307","309-403","405-4094"]
urn:sdx:port:sax.net:Sax02:41        up      enabled  ["3-4094"]
urn:sdx:port:sax.net:Sax02:1         up      enabled  ["1-4094"]
urn:sdx:port:sax.net:Sax02:40        up      enabled  ["3-4094"]
urn:sdx:port:sax.net:Sax02:50        up      enabled  ["1-302","304-307","309-403","405-4094"]
urn:sdx:port:tenet.ac.za:Tenet02:41  up      enabled  ["3-4094"]
urn:sdx:port:tenet.ac.za:Tenet02:1   up      enabled  ["1-4094"]
urn:sdx:port:tenet.ac.za:Tenet02:50  up      enabled  ["1-4094"]
urn:sdx:port:tenet.ac.za:Tenet03:2   up      enabled  ["1-4094"]
urn:sdx:port:tenet.ac.za:Tenet03:50  up      enabled  ["1-303","305-308","310-404","406-4094"]
urn:sdx:port:tenet.ac.za:Tenet01:41  up      enabled  ["5-4094"]
urn:sdx:port:tenet.ac.za:Tenet01:1   up      enabled  ["1-4094"]
urn:sdx:port:tenet.ac.za:Tenet01:2   up      enabled  ["1-4094"]
urn:sdx:port:tenet.ac.za:Tenet01:50  up      enabled  ["1-299","302-303","307","309-400","403-404","406-4094"]
```

Connectivity tests on all L2VPN confirm they are all operational:

```
$ curl -s http://0.0.0.0:8080/SDX-Controller/l2vpn/1.0 | jq -r '.[]|.service_id' | while read ID; do echo "---> $ID"; ./test-l2vpn-v2.sh $ID; done
---> 088db6ec-f533-4a5d-bb4e-13af079dbf16
Configuring hostA (h4)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:308:308::2 '
PING 2001:db8:308:308::2(2001:db8:308:308::2) 56 data bytes
64 bytes from 2001:db8:308:308::2: icmp_seq=1 ttl=64 time=0.103 ms
64 bytes from 2001:db8:308:308::2: icmp_seq=2 ttl=64 time=0.090 ms
64 bytes from 2001:db8:308:308::2: icmp_seq=3 ttl=64 time=0.054 ms
64 bytes from 2001:db8:308:308::2: icmp_seq=4 ttl=64 time=0.048 ms
64 bytes from 2001:db8:308:308::2: icmp_seq=5 ttl=64 time=0.057 ms

--- 2001:db8:308:308::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.048/0.070/0.103/0.021 ms
---> 2593f8e6-0491-4770-a1fd-d7f335ca0dbb
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:301:301::2 '
PING 2001:db8:301:301::2(2001:db8:301:301::2) 56 data bytes
64 bytes from 2001:db8:301:301::2: icmp_seq=1 ttl=64 time=0.156 ms
64 bytes from 2001:db8:301:301::2: icmp_seq=2 ttl=64 time=0.068 ms
64 bytes from 2001:db8:301:301::2: icmp_seq=3 ttl=64 time=0.067 ms
64 bytes from 2001:db8:301:301::2: icmp_seq=4 ttl=64 time=0.062 ms
64 bytes from 2001:db8:301:301::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:301:301::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.062/0.083/0.156/0.036 ms
---> 4d531bad-eacf-4be4-85cc-74ed0294c61a
Configuring hostA (h1)...
Configuring hostZ (h2)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:307:307::2 '
PING 2001:db8:307:307::2(2001:db8:307:307::2) 56 data bytes
64 bytes from 2001:db8:307:307::2: icmp_seq=1 ttl=64 time=0.141 ms
64 bytes from 2001:db8:307:307::2: icmp_seq=2 ttl=64 time=0.069 ms
64 bytes from 2001:db8:307:307::2: icmp_seq=3 ttl=64 time=0.054 ms
64 bytes from 2001:db8:307:307::2: icmp_seq=4 ttl=64 time=0.054 ms
64 bytes from 2001:db8:307:307::2: icmp_seq=5 ttl=64 time=0.051 ms

--- 2001:db8:307:307::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.051/0.073/0.141/0.034 ms
---> 55968fc9-53ec-4201-8032-d404773ed4fb
Configuring hostA (h4)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:303:303::2 '
PING 2001:db8:303:303::2(2001:db8:303:303::2) 56 data bytes
64 bytes from 2001:db8:303:303::2: icmp_seq=1 ttl=64 time=0.148 ms
64 bytes from 2001:db8:303:303::2: icmp_seq=2 ttl=64 time=0.082 ms
64 bytes from 2001:db8:303:303::2: icmp_seq=3 ttl=64 time=0.061 ms
64 bytes from 2001:db8:303:303::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:303:303::2: icmp_seq=5 ttl=64 time=0.055 ms

--- 2001:db8:303:303::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 817ms
rtt min/avg/max/mdev = 0.055/0.081/0.148/0.034 ms
---> 63cfe562-4df4-4cb6-9c8b-46aa18c3e11c
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:305:305::2 '
PING 2001:db8:305:305::2(2001:db8:305:305::2) 56 data bytes
64 bytes from 2001:db8:305:305::2: icmp_seq=1 ttl=64 time=0.164 ms
64 bytes from 2001:db8:305:305::2: icmp_seq=2 ttl=64 time=0.094 ms
64 bytes from 2001:db8:305:305::2: icmp_seq=3 ttl=64 time=0.063 ms
64 bytes from 2001:db8:305:305::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:305:305::2: icmp_seq=5 ttl=64 time=0.064 ms

--- 2001:db8:305:305::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 816ms
rtt min/avg/max/mdev = 0.060/0.089/0.164/0.039 ms
---> 6b63c6f0-2597-472e-8923-bde109ced6e6
Configuring hostA (h1)...
Configuring hostZ (h2)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:302:302::2 '
PING 2001:db8:302:302::2(2001:db8:302:302::2) 56 data bytes
64 bytes from 2001:db8:302:302::2: icmp_seq=1 ttl=64 time=0.091 ms
64 bytes from 2001:db8:302:302::2: icmp_seq=2 ttl=64 time=0.067 ms
64 bytes from 2001:db8:302:302::2: icmp_seq=3 ttl=64 time=0.071 ms
64 bytes from 2001:db8:302:302::2: icmp_seq=4 ttl=64 time=0.057 ms
64 bytes from 2001:db8:302:302::2: icmp_seq=5 ttl=64 time=0.076 ms

--- 2001:db8:302:302::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.057/0.072/0.091/0.011 ms
---> aa46a6c1-dc8f-416d-bfcf-6cefe6c5984c
Configuring hostA (h6)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 107 ping6 -c5 -i0.2 2001:db8:304:304::2 '
PING 2001:db8:304:304::2(2001:db8:304:304::2) 56 data bytes
64 bytes from 2001:db8:304:304::2: icmp_seq=1 ttl=64 time=0.111 ms
64 bytes from 2001:db8:304:304::2: icmp_seq=2 ttl=64 time=0.072 ms
64 bytes from 2001:db8:304:304::2: icmp_seq=3 ttl=64 time=0.058 ms
64 bytes from 2001:db8:304:304::2: icmp_seq=4 ttl=64 time=0.059 ms
64 bytes from 2001:db8:304:304::2: icmp_seq=5 ttl=64 time=0.059 ms

--- 2001:db8:304:304::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 819ms
rtt min/avg/max/mdev = 0.058/0.071/0.111/0.020 ms
---> add8e7f7-4fbf-4f8b-8e39-31b61e3996d8
Configuring hostA (h4)...
Configuring hostZ (h5)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 135 ping6 -c5 -i0.2 2001:db8:404:404::2 '
PING 2001:db8:404:404::2(2001:db8:404:404::2) 56 data bytes
64 bytes from 2001:db8:404:404::2: icmp_seq=1 ttl=64 time=0.090 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=2 ttl=64 time=0.086 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=3 ttl=64 time=0.082 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=4 ttl=64 time=0.052 ms
64 bytes from 2001:db8:404:404::2: icmp_seq=5 ttl=64 time=0.057 ms

--- 2001:db8:404:404::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.052/0.073/0.090/0.015 ms
---> bcb0544b-666d-4c10-9d02-bf192360b4c5
Configuring hostA (h1)...
Configuring hostZ (h2)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 167 ping6 -c5 -i0.2 2001:db8:403:403::2 '
PING 2001:db8:403:403::2(2001:db8:403:403::2) 56 data bytes
64 bytes from 2001:db8:403:403::2: icmp_seq=1 ttl=64 time=0.147 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=2 ttl=64 time=0.087 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=3 ttl=64 time=0.055 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=4 ttl=64 time=0.060 ms
64 bytes from 2001:db8:403:403::2: icmp_seq=5 ttl=64 time=0.061 ms

--- 2001:db8:403:403::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.055/0.082/0.147/0.034 ms
---> bd4030dc-7705-4f28-a0a1-f9a94aaad6c7
Configuring hostA (h6)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 107 ping6 -c5 -i0.2 2001:db8:308:309::2 '
PING 2001:db8:308:309::2(2001:db8:308:309::2) 56 data bytes
64 bytes from 2001:db8:308:309::2: icmp_seq=1 ttl=64 time=0.155 ms
64 bytes from 2001:db8:308:309::2: icmp_seq=2 ttl=64 time=0.086 ms
64 bytes from 2001:db8:308:309::2: icmp_seq=3 ttl=64 time=0.061 ms
64 bytes from 2001:db8:308:309::2: icmp_seq=4 ttl=64 time=0.062 ms
64 bytes from 2001:db8:308:309::2: icmp_seq=5 ttl=64 time=0.058 ms

--- 2001:db8:308:309::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.058/0.084/0.155/0.036 ms
---> d08216af-34ae-432c-a761-82d622df0673
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:306:306::2 '
PING 2001:db8:306:306::2(2001:db8:306:306::2) 56 data bytes
64 bytes from 2001:db8:306:306::2: icmp_seq=1 ttl=64 time=0.205 ms
64 bytes from 2001:db8:306:306::2: icmp_seq=2 ttl=64 time=0.069 ms
64 bytes from 2001:db8:306:306::2: icmp_seq=3 ttl=64 time=0.091 ms
64 bytes from 2001:db8:306:306::2: icmp_seq=4 ttl=64 time=0.071 ms
64 bytes from 2001:db8:306:306::2: icmp_seq=5 ttl=64 time=0.077 ms

--- 2001:db8:306:306::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.069/0.102/0.205/0.051 ms
---> d627da1e-ac17-4cc2-ac5a-c0b36a7ad09c
Configuring hostA (h6)...
Configuring hostZ (h8)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 107 ping6 -c5 -i0.2 2001:db8:405:405::2 '
PING 2001:db8:405:405::2(2001:db8:405:405::2) 56 data bytes
64 bytes from 2001:db8:405:405::2: icmp_seq=1 ttl=64 time=0.154 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=2 ttl=64 time=0.057 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=3 ttl=64 time=0.063 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=4 ttl=64 time=0.079 ms
64 bytes from 2001:db8:405:405::2: icmp_seq=5 ttl=64 time=0.061 ms

--- 2001:db8:405:405::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 812ms
rtt min/avg/max/mdev = 0.057/0.082/0.154/0.036 ms
---> ea12aac0-44ca-44f7-9ed7-08082c836768
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:401:401::2 '
PING 2001:db8:401:401::2(2001:db8:401:401::2) 56 data bytes
64 bytes from 2001:db8:401:401::2: icmp_seq=1 ttl=64 time=0.108 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=2 ttl=64 time=0.138 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=3 ttl=64 time=0.080 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=4 ttl=64 time=0.073 ms
64 bytes from 2001:db8:401:401::2: icmp_seq=5 ttl=64 time=0.066 ms

--- 2001:db8:401:401::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 814ms
rtt min/avg/max/mdev = 0.066/0.093/0.138/0.026 ms
---> f6afb238-10de-4b21-9fb3-1c2dbe7fe4b8
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:300:300::2 '
PING 2001:db8:300:300::2(2001:db8:300:300::2) 56 data bytes
64 bytes from 2001:db8:300:300::2: icmp_seq=1 ttl=64 time=0.131 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=2 ttl=64 time=0.092 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=3 ttl=64 time=0.152 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=4 ttl=64 time=0.165 ms
64 bytes from 2001:db8:300:300::2: icmp_seq=5 ttl=64 time=0.112 ms

--- 2001:db8:300:300::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 819ms
rtt min/avg/max/mdev = 0.092/0.130/0.165/0.026 ms
---> f6f6f770-72e4-494e-8c96-6f8f41408c30
Configuring hostA (h3)...
Configuring hostZ (h6)...
Learning MAC addresses...
ping test HostA - HostB
+ docker exec 6776d622a6c829e63bd0614b8a4f27b305ccab47d5d42f5716c14675a03df5d5 bash -c 'mnexec -a 171 ping6 -c5 -i0.2 2001:db8:402:402::2 '
PING 2001:db8:402:402::2(2001:db8:402:402::2) 56 data bytes
64 bytes from 2001:db8:402:402::2: icmp_seq=1 ttl=64 time=0.125 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=2 ttl=64 time=0.079 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=3 ttl=64 time=0.092 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=4 ttl=64 time=0.079 ms
64 bytes from 2001:db8:402:402::2: icmp_seq=5 ttl=64 time=0.086 ms

--- 2001:db8:402:402::2 ping statistics ---
5 packets transmitted, 5 received, 0% packet loss, time 815ms
rtt min/avg/max/mdev = 0.079/0.092/0.125/0.017 ms
```