### PR TITLE
Fix max_number_oxps metric validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sdx-pce"
-version = "3.1.0.dev2"
+version = "3.1.0.dev4"
 description = "Heuristic and Optimal Algorithms for CSP and TE Computation"
 authors = [
     { name = "Yufeng Xin", email = "yxin@renci.org" },

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -830,7 +830,9 @@ class TEManager:
                 connection_request["egress_port"]["id"],
             )
             self._logger.info(f"same_domain_user_port_flag: {same_domain_port_flag}")
-            max_number_oxps = connection_request.get("max_number_oxps") or max_number_oxps
+            max_number_oxps = (
+                connection_request.get("max_number_oxps") or max_number_oxps
+            )
 
         # Now generate the breakdown with potential user specified tags
         ingress_user_port = None

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -811,7 +811,6 @@ class TEManager:
             f"connection_request: {connection_request}; "
             f"type: {'tm' if request_format_is_tm else 'not tm'}"
         )
-        max_number_oxps = MAX_OXP_DEFAULT
         same_domain_port_flag = False
         if not request_format_is_tm:
             connection_request = (
@@ -830,7 +829,6 @@ class TEManager:
                 connection_request["egress_port"]["id"],
             )
             self._logger.info(f"same_domain_user_port_flag: {same_domain_port_flag}")
-            max_number_oxps = connection_request.get("max_number_oxps") or max_number_oxps
 
         # Now generate the breakdown with potential user specified tags
         ingress_user_port = None
@@ -920,6 +918,7 @@ class TEManager:
             domain_breakdown[domain] = segment.copy()
             i = i + 1
 
+        max_number_oxps = connection_request.get("max_number_oxps") or MAX_OXP_DEFAULT
         if len(domain_breakdown.keys()) > max_number_oxps:
             self._logger.warning(
                 "Breakdown has more domains than max number of OXPs required in the request:"

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -925,7 +925,7 @@ class TEManager:
                 f" {len(domain_breakdown.keys())=} {max_number_oxps=}"
             )
             raise TEError(
-                f"Can't fulfill QoS requiments: max number of OXPs exceeded", 410
+                "Can't fulfill QoS requiments: max number of OXPs exceeded", 410
             )
 
         self._logger.info(

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -811,6 +811,7 @@ class TEManager:
             f"connection_request: {connection_request}; "
             f"type: {'tm' if request_format_is_tm else 'not tm'}"
         )
+        max_number_oxps = MAX_OXP_DEFAULT
         same_domain_port_flag = False
         if not request_format_is_tm:
             connection_request = (
@@ -829,6 +830,7 @@ class TEManager:
                 connection_request["egress_port"]["id"],
             )
             self._logger.info(f"same_domain_user_port_flag: {same_domain_port_flag}")
+            max_number_oxps = connection_request.get("max_number_oxps") or max_number_oxps
 
         # Now generate the breakdown with potential user specified tags
         ingress_user_port = None
@@ -918,7 +920,6 @@ class TEManager:
             domain_breakdown[domain] = segment.copy()
             i = i + 1
 
-        max_number_oxps = connection_request.get("max_number_oxps") or MAX_OXP_DEFAULT
         if len(domain_breakdown.keys()) > max_number_oxps:
             self._logger.warning(
                 "Breakdown has more domains than max number of OXPs required in the request:"

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -924,7 +924,9 @@ class TEManager:
                 "Breakdown has more domains than max number of OXPs required in the request:"
                 f" {len(domain_breakdown.keys())=} {max_number_oxps=}"
             )
-            raise TEError(f"Can't fulfill QoS requiments: max number of OXPs exceeded", 410)
+            raise TEError(
+                f"Can't fulfill QoS requiments: max number of OXPs exceeded", 410
+            )
 
         self._logger.info(
             f"generate_connection_breakdown(): domain_breakdown: {domain_breakdown} "

--- a/src/sdx_pce/topology/temanager.py
+++ b/src/sdx_pce/topology/temanager.py
@@ -37,6 +37,7 @@ from sdx_pce.utils.exceptions import (
 )
 
 UNUSED_VLAN = None
+MAX_OXP_DEFAULT = 4294967295
 
 
 class TEManager:
@@ -810,6 +811,7 @@ class TEManager:
             f"connection_request: {connection_request}; "
             f"type: {'tm' if request_format_is_tm else 'not tm'}"
         )
+        max_number_oxps = MAX_OXP_DEFAULT
         same_domain_port_flag = False
         if not request_format_is_tm:
             connection_request = (
@@ -828,6 +830,7 @@ class TEManager:
                 connection_request["egress_port"]["id"],
             )
             self._logger.info(f"same_domain_user_port_flag: {same_domain_port_flag}")
+            max_number_oxps = connection_request.get("max_number_oxps") or max_number_oxps
 
         # Now generate the breakdown with potential user specified tags
         ingress_user_port = None
@@ -916,6 +919,13 @@ class TEManager:
 
             domain_breakdown[domain] = segment.copy()
             i = i + 1
+
+        if len(domain_breakdown.keys()) > max_number_oxps:
+            self._logger.warning(
+                "Breakdown has more domains than max number of OXPs required in the request:"
+                f" {len(domain_breakdown.keys())=} {max_number_oxps=}"
+            )
+            raise TEError(f"Can't fulfill QoS requiments: max number of OXPs exceeded", 410)
 
         self._logger.info(
             f"generate_connection_breakdown(): domain_breakdown: {domain_breakdown} "


### PR DESCRIPTION
Fix #279 

## Description of the change

This PR adds the `max_number_oxps` QoS metric validation, which according to the specification should account for:

> max_number_oxps: The max_number_oxps sub-attribute describes the total number of OXPs in the path. When requesting a maximum number of OXPs in the path, the subkey "value" under max_number_oxps must be provided as an integer from 1 to 100.

I introduced `MAX_OXP_DEFAULT` as a way to differentiate cases where `max_number_oxps` was not required (it would be 101 as well, no difference)


## Local end-to-end tests:


```
~/sdx-end-to-end-tests$ git diff docker-compose.yml
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b430f2..4674937 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./pce/src/sdx_pce:/opt/venv/lib/python3.11/site-packages/sdx_pce
     depends_on:
       mongo:
         condition: service_healthy
~/sdx-end-to-end-tests$ cd pce && git status && cd ..
On branch fix/issue_279
Your branch is up to date with 'origin/fix/issue_279'.

nothing to commit, working tree clean
~/sdx-end-to-end-tests$ bash -x run-all.sh
+ TESTS=tests/
+ docker compose down -v
+ docker compose up -d
+ ./wait-mininet-ready.sh
+ docker compose exec -it mininet python3 -m pytest tests/
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.6.1
collected 79 items

tests/test_01_topology.py .....                                                                                                                                                                 [  6%]
tests/test_05_l2vpn.py ........                                                                                                                                                                 [ 16%]
tests/test_06_l2vpn_return_codes.py .............................X....                                                                                                                          [ 59%]
tests/test_07_l2vpn_return_codes.py .......................                                                                                                                                     [ 88%]
tests/test_08_l2vpn_return_codes.py ......                                                                                                                                                      [ 96%]
tests/test_99_topology_big_changes.py ...                                                                                                                                                       [100%]

------------------------------------------------------------------------------------------ start/stop times -------------------------------------------------------------------------------------------
============================================================================== 78 passed, 1 xpassed in 758.45s (0:12:38) ==============================================================================
```